### PR TITLE
Add HmIP-SWDM Window contact

### DIFF
--- a/custom_components/hahm/helper.py
+++ b/custom_components/hahm/helper.py
@@ -329,6 +329,10 @@ _BINARY_SENSOR_DESCRIPTIONS_BY_DEVICE_PARAM: dict[
         key="STATE",
         device_class=BinarySensorDeviceClass.WINDOW,
     ),
+    ("HmIP-SWDM", "STATE"): BinarySensorEntityDescription(
+        key="STATE",
+        device_class=BinarySensorDeviceClass.WINDOW,
+    ),
     ("HmIP-SCI", "STATE"): BinarySensorEntityDescription(
         key="STATE",
         device_class=BinarySensorDeviceClass.SAFETY,


### PR DESCRIPTION
This adds an entry to the device map to make HmIP-SWDM window contacts available.

"Homematic IP Smart Home Fenster- und Türkontakt mit Magnet HmIP-SWDM"

State is now correctly reported as opened / closed instead of generic on/off.

<img width="328" alt="Bildschirmfoto 2021-12-11 um 18 39 11" src="https://user-images.githubusercontent.com/418970/145686231-0a940768-ffa9-462d-936e-654002834bd5.png">