### PR TITLE
Bump hahomematic to 0.6.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
-Version 0.6.1 (2021-12-28)
+Version 0.6.2 (2021-12-28)
+- Add selector to service disable_away_mode
+
+Version 0.6.1 (2021-12-27)
 - Remove away mode start date
 
 Version 0.6.0 (2021-12-27)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,15 @@
 Version 0.6.2 (2021-12-28)
 - Add selector to service disable_away_mode
+- Bump hahomematic to 0.6.1:
+    - Display profiles only when hvac_mode auto is enabled
+    - Fix binary sensor state update for hmip 2-state sensors
 
 Version 0.6.1 (2021-12-27)
 - Remove away mode start date
 
 Version 0.6.0 (2021-12-27)
 - Add climate services for away mode (experimental)
-- Bump hahomematic to 0.5.0:
+- Bump hahomematic to 0.6.0:
     - Fix HVAC_MODE_OFF for climate
 
 Version 0.5.1 (2021-12-26)

--- a/custom_components/hahm/binary_sensor.py
+++ b/custom_components/hahm/binary_sensor.py
@@ -62,4 +62,4 @@ class HaHomematicBinarySensor(
     @property
     def is_on(self) -> bool:
         """Return true if motion is detected."""
-        return self._hm_entity.state is True
+        return self._hm_entity.state

--- a/custom_components/hahm/control_unit.py
+++ b/custom_components/hahm/control_unit.py
@@ -438,6 +438,9 @@ class ControlConfig:
 class HaHub(Entity):
     """The HomeMatic hub. (CCU2/HomeGear)."""
 
+    _attr_should_poll = False
+    _attr_icon = "mdi:gradient-vertical"
+
     def __init__(
         self, hass: HomeAssistant, control_unit: ControlUnit, hm_hub: HmHub | HmDummyHub
     ) -> None:
@@ -445,8 +448,8 @@ class HaHub(Entity):
         self.hass = hass
         self._control: ControlUnit = control_unit
         self._hm_hub: HmHub | HmDummyHub = hm_hub
-        self._name: str = self._control.central.instance_name
-        self.entity_id = f"{DOMAIN}.{slugify(self._name.lower())}"
+        self._attr_name: str = self._control.central.instance_name
+        self.entity_id = f"{DOMAIN}.{slugify(self._attr_name.lower())}"
         self._hm_hub.register_update_callback(self._async_update_hub)
 
     async def async_init(self) -> None:
@@ -461,16 +464,6 @@ class HaHub(Entity):
         """Return if entity is available."""
         return self._hm_hub.available
 
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def should_poll(self) -> bool:
-        """Return false. HomeMatic Hub object updates variables."""
-        return False
-
     async def _async_fetch_data(self, now: datetime) -> None:
         """Fetch data from backend."""
         await self._hm_hub.fetch_data()
@@ -484,11 +477,6 @@ class HaHub(Entity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return self._hm_hub.extra_state_attributes
-
-    @property
-    def icon(self) -> str:
-        """Return the icon to use in the frontend, if any."""
-        return "mdi:gradient-vertical"
 
     async def async_set_variable(self, name: str, value: Any) -> None:
         """Set variable value on CCU/Homegear."""

--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/hahomematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==0.6.0"],
+  "requirements": ["hahomematic==0.6.1"],
   "requirements1": ["git+https://github.com/SukramJ/hahomematic.git@dev1#hahomematic"],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -12,5 +12,5 @@
   "dependencies": [],
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
-  "version": "0.6.1"
+  "version": "0.6.2"
 }

--- a/custom_components/hahm/services.yaml
+++ b/custom_components/hahm/services.yaml
@@ -154,7 +154,7 @@ put_paramset:
 
 enable_away_mode_by_calendar:
   name: Enable climate away mode by calendar
-  description: Enable climate away mode by calendar.  (experimental)
+  description: Enable climate away mode by calendar.
   fields:
     entity_id:
       name: Entity
@@ -193,4 +193,5 @@ disable_away_mode:
       required: true
       example: climate.livingroom
       selector:
-        text:
+        entity:
+          domain: climate


### PR DESCRIPTION
- Add selector to service disable_away_mode
- Bump hahomematic to 0.6.1:
    - Display profiles only when hvac_mode auto is enabled
    - Fix binary sensor state update for hmip 2-state sensors