### PR TITLE
Update Name?

### DIFF
--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hahm",
-  "name": "Home Assistant Homematic(IP)",
+  "name": "Homematic(IP) Local",
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/hahomematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",


### PR DESCRIPTION
Gibt es einen Grund warum hier noch der alte Name der Integration steht oder wurde der nur übersehen?
Erst wenn ich den Name hier ändere, wird auch der Name in der Integration-Liste von HA aktualisiert - sonst steht dort noch der alte Name:
![image](https://user-images.githubusercontent.com/30938717/148376775-66e7a2df-b232-4aea-b74a-c51eed3210ee.png)
