### PR TITLE
Add device actions to call actions on virtual remotes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 0.15.0 (2021-01-07)
+- Bump hahomematic to 0.15.0
+    - Remove Virtual Remotes from buttons
+- Update integration name in comments
+
 Version 0.14.0 (2021-01-06)
 - Bump hahomematic to 0.14.0
     - Switch some HM-LC-Bl1 to cover

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
 Version 0.15.0 (2021-01-07)
 - Bump hahomematic to 0.15.0
-    - Remove Virtual Remotes from buttons
+    - Remove Virtual Remotes from buttons (BREAKING CHANGE)
+      Solution: obsolete entities (buttons) can be deleted in entities overview.
 - Update integration name in comments
+- Add device actions to call actions on virtual remotes
 
 Version 0.14.0 (2021-01-06)
 - Bump hahomematic to 0.14.0

--- a/custom_components/hahm/binary_sensor.py
+++ b/custom_components/hahm/binary_sensor.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -25,12 +25,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM binary_sensor platform."""
+    """Set up the Homematic(IP) Local binary_sensor platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_binary_sensor(args: Any) -> None:
-        """Add binary_sensor from HAHM."""
+        """Add binary_sensor from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/button.py
+++ b/custom_components/hahm/button.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -25,12 +25,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM binary_sensor platform."""
+    """Set up the Homematic(IP) Local binary_sensor platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_button(args: Any) -> None:
-        """Add button from HAHM."""
+        """Add button from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/climate.py
+++ b/custom_components/hahm/climate.py
@@ -1,4 +1,4 @@
-"""climate for HAHM."""
+"""climate for Homematic(IP) Local."""
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -36,12 +36,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM climate platform."""
+    """Set up the Homematic(IP) Local climate platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_climate(args: Any) -> None:
-        """Add climate from HAHM."""
+        """Add climate from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/config_flow.py
+++ b/custom_components/hahm/config_flow.py
@@ -242,21 +242,21 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class HahmOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle hahm options."""
+    """Handle Homematic(IP) Local options."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize hahm options flow."""
+        """Initialize Homematic(IP) Local options flow."""
         self.config_entry = config_entry
         self.data: ConfigType = dict(self.config_entry.data.items())
 
     async def async_step_init(self, user_input: ConfigType | None = None) -> FlowResult:
-        """Manage the hahm options."""
+        """Manage the Homematic(IP) Local options."""
         return await self.async_step_central(user_input=user_input)
 
     async def async_step_central(
         self, user_input: ConfigType | None = None
     ) -> FlowResult:
-        """Manage the hahm devices options."""
+        """Manage the Homematic(IP) Local devices options."""
         if user_input is not None:
             self.data = _get_ccu_data(self.data, user_input=user_input)
             return await self.async_step_interface()

--- a/custom_components/hahm/const.py
+++ b/custom_components/hahm/const.py
@@ -26,7 +26,7 @@ SERVICE_VIRTUAL_KEY = "virtual_key"
 
 
 def _get_hahm_platforms() -> list[str]:
-    """Return relevant hahm platforms."""
+    """Return relevant Homematic(IP) Local platforms."""
     platforms = [entry.value for entry in Platform]
     hm_platforms = [entry.value for entry in AVAILABLE_HM_PLATFORMS]
     hahm_platforms: list[str] = []

--- a/custom_components/hahm/const.py
+++ b/custom_components/hahm/const.py
@@ -17,6 +17,9 @@ ATTR_VALUE_TYPE = "value_type"
 
 CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES = "enable_sensors_for_system_variables"
 CONF_ENABLE_VIRTUAL_CHANNELS = "enable_virtual_channels"
+CONF_INTERFACE_ID = "interface_id"
+CONF_EVENT_TYPE = "event_type"
+CONF_SUBTYPE = "subtype"
 
 SERVICE_PUT_PARAMSET = "put_paramset"
 SERVICE_SET_DEVICE_VALUE = "set_device_value"

--- a/custom_components/hahm/control_unit.py
+++ b/custom_components/hahm/control_unit.py
@@ -87,7 +87,7 @@ class ControlUnit:
 
     async def async_start(self) -> None:
         """Start the control unit."""
-        _LOGGER.debug("Starting HAHM ControlUnit %s", self._data[ATTR_INSTANCE_NAME])
+        _LOGGER.debug("Starting Homematic(IP) Local ControlUnit %s", self._data[ATTR_INSTANCE_NAME])
         if self._central:
             await self.async_create_clients()
             self._central.create_devices()
@@ -96,7 +96,7 @@ class ControlUnit:
             self._central.start_connection_checker()
         else:
             _LOGGER.exception(
-                "Starting HAHM ControlUnit %s not possible, CentralUnit is not available",
+                "Starting Homematic(IP) Local ControlUnit %s not possible, CentralUnit is not available",
                 self._data[ATTR_INSTANCE_NAME],
             )
 
@@ -115,7 +115,7 @@ class ControlUnit:
 
     async def async_stop(self) -> None:
         """Stop the control unit."""
-        _LOGGER.debug("Stopping HAHM ControlUnit %s", self._data[ATTR_INSTANCE_NAME])
+        _LOGGER.debug("Stopping Homematic(IP) Local ControlUnit %s", self._data[ATTR_INSTANCE_NAME])
         if self._hub:
             self._hub.de_init()
         self.central.stop_connection_checker()
@@ -155,10 +155,10 @@ class ControlUnit:
 
     @property
     def central(self) -> CentralUnit:
-        """Return the HAHM central_unit instance."""
+        """Return the Homematic(IP) Local central_unit instance."""
         if self._central is not None:
             return self._central
-        raise HomeAssistantError("hahm.central not initialized")
+        raise HomeAssistantError("homematicip_local.central not initialized")
 
     @callback
     def async_get_hm_entity(self, entity_id: str) -> HmBaseEntity | None:

--- a/custom_components/hahm/control_unit.py
+++ b/custom_components/hahm/control_unit.py
@@ -87,7 +87,10 @@ class ControlUnit:
 
     async def async_start(self) -> None:
         """Start the control unit."""
-        _LOGGER.debug("Starting Homematic(IP) Local ControlUnit %s", self._data[ATTR_INSTANCE_NAME])
+        _LOGGER.debug(
+            "Starting Homematic(IP) Local ControlUnit %s",
+            self._data[ATTR_INSTANCE_NAME],
+        )
         if self._central:
             await self.async_create_clients()
             self._central.create_devices()
@@ -115,7 +118,10 @@ class ControlUnit:
 
     async def async_stop(self) -> None:
         """Stop the control unit."""
-        _LOGGER.debug("Stopping Homematic(IP) Local ControlUnit %s", self._data[ATTR_INSTANCE_NAME])
+        _LOGGER.debug(
+            "Stopping Homematic(IP) Local ControlUnit %s",
+            self._data[ATTR_INSTANCE_NAME],
+        )
         if self._hub:
             self._hub.de_init()
         self.central.stop_connection_checker()
@@ -264,7 +270,9 @@ class ControlUnit:
                 # HA only needs channel_addresses
                 if ":" in address:
                     continue
-                if entities := self._get_active_entities_by_device_address(device_address=address):
+                if entities := self._get_active_entities_by_device_address(
+                    device_address=address
+                ):
                     for entity in entities:
                         entity.remove_entity()
             return None
@@ -405,11 +413,16 @@ class ControlUnit:
             )
         return clients
 
-    def _get_active_entities_by_device_address(self, device_address: str) -> list[HmBaseEntity]:
+    def _get_active_entities_by_device_address(
+        self, device_address: str
+    ) -> list[HmBaseEntity]:
         """Return used hm_entities by address."""
         entities: list[HmBaseEntity] = []
         for entity in self._active_hm_entities.values():
-            if isinstance(entity, HmCallbackEntity) and device_address == entity.device_address:
+            if (
+                isinstance(entity, HmCallbackEntity)
+                and device_address == entity.device_address
+            ):
                 entities.append(entity)
         return entities
 

--- a/custom_components/hahm/cover.py
+++ b/custom_components/hahm/cover.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 from abc import ABC
@@ -30,12 +30,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM cover platform."""
+    """Set up the Homematic(IP) Local cover platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_cover(args: Any) -> None:
-        """Add cover from HAHM."""
+        """Add cover from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/device_action.py
+++ b/custom_components/hahm/device_action.py
@@ -1,0 +1,78 @@
+"""Provides device actions for Homematic(IP) Local."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
+
+from . import DOMAIN
+
+# TODO specify your supported action types.
+ACTION_TYPES = {"turn_on", "turn_off"}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+    }
+)
+
+
+async def async_get_actions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device actions for Homematic(IP) Local devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    actions = []
+
+    # TODO Read this comment and remove it.
+    # This example shows how to iterate over the entities of this device
+    # that match this integration. If your actions instead rely on
+    # calling services, do something like:
+    # zha_device = await _async_get_zha_device(hass, device_id)
+    # return zha_device.device_actions
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add actions for each entity that belongs to this integration
+        # TODO add your own actions.
+        base_action = {
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.entity_id,
+        }
+
+        actions.append({**base_action, CONF_TYPE: "turn_on"})
+        actions.append({**base_action, CONF_TYPE: "turn_off"})
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Context | None
+) -> None:
+    """Execute a device action."""
+    service_data = {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]}
+
+    if config[CONF_TYPE] == "turn_on":
+        service = SERVICE_TURN_ON
+    elif config[CONF_TYPE] == "turn_off":
+        service = SERVICE_TURN_OFF
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, blocking=True, context=context
+    )

--- a/custom_components/hahm/helpers.py
+++ b/custom_components/hahm/helpers.py
@@ -11,7 +11,7 @@ from hahomematic.hub import BaseHubEntity
 HmBaseEntity = Union[BaseHubEntity, BaseParameterEntity, CustomEntity, GenericEntity]
 # Entities that support callbacks from backend
 HmCallbackEntity = (CustomEntity, GenericEntity)
-# Generic base type usedcfor entities in hahm
+# Generic base type used for entities in Homematic(IP) Local
 HmGenericEntity = TypeVar("HmGenericEntity", bound=HmBaseEntity)
 
 

--- a/custom_components/hahm/helpers.py
+++ b/custom_components/hahm/helpers.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 from typing import TypeVar, Union
 
 from hahomematic.const import IDENTIFIERS_SEPARATOR
-from hahomematic.entity import BaseParameterEntity, CustomEntity, GenericEntity
+from hahomematic.entity import CustomEntity, GenericEntity
 from hahomematic.hub import BaseHubEntity
 
 # Union for entity types used as base class for entities
-HmBaseEntity = Union[BaseHubEntity, BaseParameterEntity, CustomEntity, GenericEntity]
+HmBaseEntity = Union[BaseHubEntity, CustomEntity, GenericEntity]
 # Entities that support callbacks from backend
 HmCallbackEntity = (CustomEntity, GenericEntity)
 # Generic base type used for entities in Homematic(IP) Local

--- a/custom_components/hahm/light.py
+++ b/custom_components/hahm/light.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -30,12 +30,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM light platform."""
+    """Set up the Homematic(IP) Local light platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_light(args: Any) -> None:
-        """Add light from HAHM."""
+        """Add light from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/lock.py
+++ b/custom_components/hahm/lock.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -25,12 +25,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM lock platform."""
+    """Set up the Homematic(IP) Local lock platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_lock(args: Any) -> None:
-        """Add lock from HAHM."""
+        """Add lock from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/hahomematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==0.14.0"],
+  "requirements": ["hahomematic==0.15.0"],
   "requirements1": ["git+https://github.com/SukramJ/hahomematic.git@dev1#hahomematic"],
   "ssdp": [],
   "zeroconf": [],
@@ -12,5 +12,5 @@
   "dependencies": [],
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
-  "version": "0.14.0"
+  "version": "0.15.0"
 }

--- a/custom_components/hahm/number.py
+++ b/custom_components/hahm/number.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -26,12 +26,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM number platform."""
+    """Set up the Homematic(IP) Local number platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_number(args: Any) -> None:
-        """Add number from HAHM."""
+        """Add number from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/select.py
+++ b/custom_components/hahm/select.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -26,12 +26,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM select platform."""
+    """Set up the Homematic(IP) Local select platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_select(args: Any) -> None:
-        """Add select from HAHM."""
+        """Add select from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:

--- a/custom_components/hahm/sensor.py
+++ b/custom_components/hahm/sensor.py
@@ -1,4 +1,4 @@
-"""binary_sensor for HAHM."""
+"""binary_sensor for Homematic(IP) Local."""
 from __future__ import annotations
 
 from datetime import timedelta
@@ -29,12 +29,12 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM sensor platform."""
+    """Set up the Homematic(IP) Local sensor platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback
     def async_add_sensor(args: Any) -> None:
-        """Add sensor from HAHM."""
+        """Add sensor from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
         for hm_entity in args[0]:
@@ -44,7 +44,7 @@ async def async_setup_entry(
             async_add_entities(entities)
 
     def async_add_hub_sensors(args: Any) -> None:
-        """Add hub sensor from HAHM."""
+        """Add hub sensor from Homematic(IP) Local."""
 
         entities = []
 

--- a/custom_components/hahm/services.py
+++ b/custom_components/hahm/services.py
@@ -192,11 +192,7 @@ async def _async_service_delete_device(
     """Service to delete a HomeMatic device from HA."""
     device_id = service.data[ATTR_DEVICE_ID]
 
-    if (
-            address_data := _get_interface_address(
-                hass=hass, device_id=device_id
-            )
-    ) is None:
+    if (address_data := _get_interface_address(hass=hass, device_id=device_id)) is None:
         return None
 
     interface_id: str = address_data[0]
@@ -204,9 +200,11 @@ async def _async_service_delete_device(
 
     if interface_id and device_address:
         if control_unit := _get_cu_by_interface_id(
-                hass=hass, interface_id=interface_id
+            hass=hass, interface_id=interface_id
         ):
-            await control_unit.central.delete_device(interface_id=interface_id, device_address=device_address)
+            await control_unit.central.delete_device(
+                interface_id=interface_id, device_address=device_address
+            )
             _LOGGER.debug(
                 "Called delete_device: %s, %s",
                 interface_id,

--- a/custom_components/hahm/services.py
+++ b/custom_components/hahm/services.py
@@ -178,7 +178,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
 
 async def async_unload_services(hass: HomeAssistant) -> None:
-    """Unload HAHM services."""
+    """Unload Homematic(IP) Local services."""
     if hass.data[DOMAIN]:
         return
 

--- a/custom_components/hahm/strings.json
+++ b/custom_components/hahm/strings.json
@@ -101,8 +101,8 @@
       "press_long_start": "Button \"{subtype}\" started long press"
     },
     "action_type": {
-      "turn_on": "Turn on {entity_name}",
-      "turn_off": "Turn off {entity_name}"
+      "press_short": "Short press Button \"{subtype}\"",
+      "press_long": "Long press Button \"{subtype}\""
     }
   }
 }

--- a/custom_components/hahm/strings.json
+++ b/custom_components/hahm/strings.json
@@ -99,6 +99,10 @@
       "press_cont": "Button \"{subtype}\" continuously pressed",
       "press_long_release": "Button \"{subtype}\" long press released",
       "press_long_start": "Button \"{subtype}\" started long press"
+    },
+    "action_type": {
+      "turn_on": "Turn on {entity_name}",
+      "turn_off": "Turn off {entity_name}"
     }
   }
 }

--- a/custom_components/hahm/switch.py
+++ b/custom_components/hahm/switch.py
@@ -1,4 +1,4 @@
-"""binary_switch for HAHM."""
+"""binary_switch for Homematic(IP) Local."""
 from __future__ import annotations
 
 import logging
@@ -26,7 +26,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the HAHM switch platform."""
+    """Set up the Homematic(IP) Local switch platform."""
     control_unit: ControlUnit = hass.data[DOMAIN][config_entry.entry_id]
 
     @callback

--- a/custom_components/hahm/translations/de.json
+++ b/custom_components/hahm/translations/de.json
@@ -99,6 +99,10 @@
       "press_cont": "Taster \"{subtype}\" wird dauerhaft gedrückt",
       "press_long_release": "Taster \"{subtype}\" wurde nach langem Tastendruck los gelassen",
       "press_long_start": "Taster \"{subtype}\" hat langen Tastendruck gestartet"
+    },
+    "action_type": {
+      "press_short": "Kurzer Tastendruck auf Taster \"{subtype}\"",
+      "press_long": "Langer Tastendruck auf Taster \"{subtype}\""
     }
   }
 }

--- a/custom_components/hahm/translations/en.json
+++ b/custom_components/hahm/translations/en.json
@@ -99,6 +99,10 @@
       "press_cont": "Button \"{subtype}\" continuously pressed",
       "press_long_release": "Button \"{subtype}\" long press released",
       "press_long_start": "Button \"{subtype}\" started long press"
+    },
+    "action_type": {
+      "press_short": "Short press Button \"{subtype}\"",
+      "press_long": "Long press Button \"{subtype}\""
     }
   }
 }

--- a/tests/hahm/test_device_action.py
+++ b/tests/hahm/test_device_action.py
@@ -34,7 +34,7 @@ async def test_get_actions(
     device_reg: device_registry.DeviceRegistry,
     entity_reg: entity_registry.EntityRegistry,
 ) -> None:
-    """Test we get the expected actions from a hahm."""
+    """Test we get the expected actions from a Homematic(IP) Local."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_reg.async_get_or_create(

--- a/tests/hahm/test_device_action.py
+++ b/tests/hahm/test_device_action.py
@@ -1,0 +1,109 @@
+"""The tests for Homematic(IP) Local device actions."""
+import pytest
+
+from homeassistant.components import automation
+from homeassistant.components.hahm import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+
+
+@pytest.fixture
+def device_reg(hass: HomeAssistant) -> device_registry.DeviceRegistry:
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass: HomeAssistant) -> entity_registry.EntityRegistry:
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_reg: device_registry.DeviceRegistry,
+    entity_reg: entity_registry.EntityRegistry,
+) -> None:
+    """Test we get the expected actions from a hahm."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_actions = [
+        {
+            "domain": DOMAIN,
+            "type": "turn_on",
+            "device_id": device_entry.id,
+            "entity_id": "hahm.test_5678",
+        },
+        {
+            "domain": DOMAIN,
+            "type": "turn_off",
+            "device_id": device_entry.id,
+            "entity_id": "hahm.test_5678",
+        },
+    ]
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_action(hass: HomeAssistant) -> None:
+    """Test for turn_on and turn_off actions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event_turn_off",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "hahm.entity",
+                        "type": "turn_off",
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event_turn_on",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "hahm.entity",
+                        "type": "turn_on",
+                    },
+                },
+            ]
+        },
+    )
+
+    turn_off_calls = async_mock_service(hass, "hahm", "turn_off")
+    turn_on_calls = async_mock_service(hass, "hahm", "turn_on")
+
+    hass.bus.async_fire("test_event_turn_off")
+    await hass.async_block_till_done()
+    assert len(turn_off_calls) == 1
+    assert len(turn_on_calls) == 0
+
+    hass.bus.async_fire("test_event_turn_on")
+    await hass.async_block_till_done()
+    assert len(turn_off_calls) == 1
+    assert len(turn_on_calls) == 1

--- a/tests/hahm/test_device_trigger.py
+++ b/tests/hahm/test_device_trigger.py
@@ -1,0 +1,134 @@
+"""The tests for Homematic(IP) Local device triggers."""
+import pytest
+
+from homeassistant.components import automation
+from homeassistant.components.hahm import DOMAIN
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(hass, device_reg, entity_reg):
+    """Test we get the expected triggers from a hahm."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "turned_off",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "turned_on",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_state_change(hass, calls):
+    """Test for turn_on and turn_off triggers firing."""
+    hass.states.async_set("hahm.entity", STATE_OFF)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "hahm.entity",
+                        "type": "turned_on",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_on - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "hahm.entity",
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_off - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is turning on.
+    hass.states.async_set("hahm.entity", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data[
+        "some"
+    ] == "turn_on - device - {} - off - on - None - 0".format("hahm.entity")
+
+    # Fake that the entity is turning off.
+    hass.states.async_set("hahm.entity", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data[
+        "some"
+    ] == "turn_off - device - {} - on - off - None - 0".format("hahm.entity")


### PR DESCRIPTION
- Bump hahomematic to 0.15.0
    - Remove Virtual Remotes from buttons (BREAKING CHANGE)
      Solution: obsolete entities (buttons) can be deleted in entities overview.
- Update integration name in comments
- Add device actions to call actions on virtual remotes