### PR TITLE
Remove enable_sensors_for_system_variables from config flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 0.17.2 (2021-01-10)
 - Bump hahomematic to 0.17.2
     - Add config option to specify storage directory
+- Set entity enabled default by entity usage enum
 
 Version 0.17.1 (2021-01-09)
 - Bump hahomematic to 0.17.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,10 @@
-Version 0.17.2 (2021-01-10)
-- Bump hahomematic to 0.17.2
-    - Add config option to specify storage directory
+Version 0.18.0 (2021-01-10)
+- Bump hahomematic to 0.18.0
 - Set entity enabled default by entity usage enum
+- Remove enable_sensors_for_system_variables from config flow
+- Bool SysVars are now binary sensors
+- All Sysvars are now disabled by default
+- Add instance name to system variable name
 
 Version 0.17.1 (2021-01-09)
 - Bump hahomematic to 0.17.1

--- a/custom_components/hahm/__init__.py
+++ b/custom_components/hahm/__init__.py
@@ -6,12 +6,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import (
-    CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES,
-    CONF_ENABLE_VIRTUAL_CHANNELS,
-    DOMAIN,
-    HAHM_PLATFORMS,
-)
+from .const import CONF_ENABLE_VIRTUAL_CHANNELS, DOMAIN, HAHM_PLATFORMS
 from .control_unit import ControlConfig
 from .services import async_setup_services, async_unload_services
 

--- a/custom_components/hahm/binary_sensor.py
+++ b/custom_components/hahm/binary_sensor.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
+from hahomematic.hub import HmSystemVariable
 from hahomematic.platforms.binary_sensor import HmBinarySensor
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -33,8 +34,20 @@ async def async_setup_entry(
         """Add binary_sensor from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicBinarySensor(control_unit, hm_entity))
+
+        if entities:
+            async_add_entities(entities)
+
+    @callback
+    def async_add_hub_binary_sensors(args: Any) -> None:
+        """Add hub binary sensor from Homematic(IP) Local."""
+
+        entities = []
+
+        for hm_entity in args:
+            entities.append(HaHomematicHubBinarySensor(control_unit, hm_entity))
 
         if entities:
             async_add_entities(entities)
@@ -48,9 +61,18 @@ async def async_setup_entry(
             async_add_binary_sensor,
         )
     )
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            control_unit.async_signal_new_hm_entity(
+                config_entry.entry_id, HmPlatform.HUB_BINARY_SENSOR
+            ),
+            async_add_hub_binary_sensors,
+        )
+    )
 
     async_add_binary_sensor(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.BINARY_SENSOR)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.BINARY_SENSOR)
     )
 
 
@@ -61,5 +83,25 @@ class HaHomematicBinarySensor(
 
     @property
     def is_on(self) -> bool:
-        """Return true if motion is detected."""
+        """Return true if sensor is active."""
         return self._hm_entity.value
+
+
+class HaHomematicHubBinarySensor(
+    HaHomematicGenericEntity[HmSystemVariable], BinarySensorEntity
+):
+    """Representation of the HomematicIP hub binary_sensor entity."""
+
+    def __init__(
+        self,
+        control_unit: ControlUnit,
+        hm_entity: HmSystemVariable,
+    ) -> None:
+        """Initialize the binary_sensor entity."""
+        super().__init__(control_unit=control_unit, hm_entity=hm_entity)
+        self._attr_entity_registry_enabled_default = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return the native value of the entity."""
+        return bool(self._hm_entity.value)

--- a/custom_components/hahm/button.py
+++ b/custom_components/hahm/button.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
         """Add button from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicButton(control_unit, hm_entity))
 
         if entities:
@@ -50,7 +50,7 @@ async def async_setup_entry(
     )
 
     async_add_button(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.BUTTON)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.BUTTON)
     )
 
 

--- a/custom_components/hahm/climate.py
+++ b/custom_components/hahm/climate.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
         """Add climate from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicClimate(control_unit, hm_entity))
 
         if entities:
@@ -61,7 +61,7 @@ async def async_setup_entry(
     )
 
     async_add_climate(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.CLIMATE)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.CLIMATE)
     )
 
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/hahm/config_flow.py
+++ b/custom_components/hahm/config_flow.py
@@ -34,7 +34,6 @@ from .const import (
     ATTR_INSTANCE_NAME,
     ATTR_INTERFACE,
     ATTR_PATH,
-    CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES,
     CONF_ENABLE_VIRTUAL_CHANNELS,
     DOMAIN,
 )
@@ -94,10 +93,6 @@ def get_domain_schema(data: ConfigType) -> Schema:
             ): cv.port,
             vol.Optional(
                 CONF_ENABLE_VIRTUAL_CHANNELS,
-                default=data.get(CONF_ENABLE_VIRTUAL_CHANNELS) or False,
-            ): bool,
-            vol.Optional(
-                CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES,
                 default=data.get(CONF_ENABLE_VIRTUAL_CHANNELS) or False,
             ): bool,
         }
@@ -329,9 +324,6 @@ def _get_ccu_data(data: ConfigType, user_input: ConfigType) -> ConfigType:
         ATTR_TLS: user_input.get(ATTR_TLS),
         ATTR_VERIFY_TLS: user_input.get(ATTR_VERIFY_TLS),
         CONF_ENABLE_VIRTUAL_CHANNELS: user_input.get(CONF_ENABLE_VIRTUAL_CHANNELS),
-        CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES: user_input.get(
-            CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES
-        ),
         ATTR_INTERFACE: {},
     }
 

--- a/custom_components/hahm/const.py
+++ b/custom_components/hahm/const.py
@@ -15,7 +15,6 @@ ATTR_PATH = "path"
 ATTR_RX_MODE = "rx_mode"
 ATTR_VALUE_TYPE = "value_type"
 
-CONF_ENABLE_SENSORS_FOR_SYSTEM_VARIABLES = "enable_sensors_for_system_variables"
 CONF_ENABLE_VIRTUAL_CHANNELS = "enable_virtual_channels"
 CONF_INTERFACE_ID = "interface_id"
 CONF_EVENT_TYPE = "event_type"

--- a/custom_components/hahm/cover.py
+++ b/custom_components/hahm/cover.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
         """Add cover from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             if isinstance(hm_entity, CeBlind):
                 entities.append(HaHomematicBlind(control_unit, hm_entity))
             elif isinstance(hm_entity, CeCover):
@@ -60,7 +60,7 @@ async def async_setup_entry(
     )
 
     async_add_cover(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.COVER)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.COVER)
     )
 
 

--- a/custom_components/hahm/light.py
+++ b/custom_components/hahm/light.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
         """Add light from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicLight(control_unit, hm_entity))
 
         if entities:
@@ -55,7 +55,7 @@ async def async_setup_entry(
     )
 
     async_add_light(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.LIGHT)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.LIGHT)
     )
 
 

--- a/custom_components/hahm/lock.py
+++ b/custom_components/hahm/lock.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
         """Add lock from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicLock(control_unit, hm_entity))
 
         if entities:
@@ -49,9 +49,7 @@ async def async_setup_entry(
         )
     )
 
-    async_add_lock(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.LOCK)]
-    )
+    async_add_lock(control_unit.async_get_new_hm_entities_by_platform(HmPlatform.LOCK))
 
 
 class HaHomematicLock(HaHomematicGenericEntity[BaseLock], LockEntity):

--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/hahomematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==0.17.2"],
+  "requirements": ["hahomematic==0.18.0"],
   "requirements1": ["git+https://github.com/SukramJ/hahomematic.git@dev1#hahomematic"],
   "ssdp": [],
   "zeroconf": [],
@@ -12,5 +12,5 @@
   "dependencies": [],
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
-  "version": "0.17.2"
+  "version": "0.18.0"
 }

--- a/custom_components/hahm/number.py
+++ b/custom_components/hahm/number.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
         """Add number from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicNumber(control_unit, hm_entity))
 
         if entities:
@@ -51,7 +51,7 @@ async def async_setup_entry(
     )
 
     async_add_number(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.NUMBER)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.NUMBER)
     )
 
 

--- a/custom_components/hahm/select.py
+++ b/custom_components/hahm/select.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
         """Add select from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicSelect(control_unit, hm_entity))
 
         if entities:
@@ -51,7 +51,7 @@ async def async_setup_entry(
     )
 
     async_add_select(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.SELECT)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.SELECT)
     )
 
 

--- a/custom_components/hahm/sensor.py
+++ b/custom_components/hahm/sensor.py
@@ -37,18 +37,19 @@ async def async_setup_entry(
         """Add sensor from Homematic(IP) Local."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicSensor(control_unit, hm_entity))
 
         if entities:
             async_add_entities(entities)
 
+    @callback
     def async_add_hub_sensors(args: Any) -> None:
         """Add hub sensor from Homematic(IP) Local."""
 
         entities = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicHubSensor(control_unit, hm_entity))
 
         if entities:
@@ -67,14 +68,14 @@ async def async_setup_entry(
         async_dispatcher_connect(
             hass,
             control_unit.async_signal_new_hm_entity(
-                config_entry.entry_id, HmPlatform.HUB
+                config_entry.entry_id, HmPlatform.HUB_SENSOR
             ),
             async_add_hub_sensors,
         )
     )
 
     async_add_sensor(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.SENSOR)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.SENSOR)
     )
 
 
@@ -98,6 +99,7 @@ class HaHomematicHubSensor(HaHomematicGenericEntity[HmSystemVariable], SensorEnt
         """Initialize the sensor entity."""
         super().__init__(control_unit=control_unit, hm_entity=hm_entity)
         self._attr_native_unit_of_measurement = hm_entity.unit
+        self._attr_entity_registry_enabled_default = False
 
     @property
     def native_value(self) -> Any:

--- a/custom_components/hahm/strings.json
+++ b/custom_components/hahm/strings.json
@@ -15,8 +15,7 @@
           "tls": "use TLS",
           "verify_tls": "verify TLS connection",
           "json_port": "JSON-RPC Port",
-          "enable_virtual_channels": "enable virtual channels",
-          "enable_sensors_for_system_variables": "enable sensors for system variables"
+          "enable_virtual_channels": "enable virtual channels"
         }
       },
       "interface": {
@@ -56,8 +55,7 @@
           "tls": "use TLS",
           "verify_tls": "verify TLS connection",
           "json_port": "JSON-RPC Port",
-          "enable_virtual_channels": "enable virtual channels",
-          "enable_sensors_for_system_variables": "enable sensors for system variables"
+          "enable_virtual_channels": "enable virtual channels"
         }
       },
       "interface": {

--- a/custom_components/hahm/switch.py
+++ b/custom_components/hahm/switch.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
         """Add switch from HAHM."""
         entities: list[HaHomematicGenericEntity] = []
 
-        for hm_entity in args[0]:
+        for hm_entity in args:
             entities.append(HaHomematicSwitch(control_unit, hm_entity))
 
         if entities:
@@ -51,7 +51,7 @@ async def async_setup_entry(
     )
 
     async_add_switch(
-        [control_unit.async_get_new_hm_entities_by_platform(HmPlatform.SWITCH)]
+        control_unit.async_get_new_hm_entities_by_platform(HmPlatform.SWITCH)
     )
 
 

--- a/custom_components/hahm/translations/de.json
+++ b/custom_components/hahm/translations/de.json
@@ -15,8 +15,7 @@
           "tls": "verwende TLS",
           "verify_tls": "TLS Verbindung überprüfen",
           "json_port": "JSON-RPC Port",
-          "enable_virtual_channels": "aktiviere virtuelle Gerätekanäle",
-          "enable_sensors_for_system_variables": "aktiviere Sensoren für Systemvariablen"
+          "enable_virtual_channels": "aktiviere virtuelle Gerätekanäle"
         }
       },
       "interface": {
@@ -56,8 +55,7 @@
           "tls": "verwende TLS",
           "verify_tls": "TLS Verbindung überprüfen",
           "json_port": "JSON-RPC Port",
-          "enable_virtual_channels": "aktiviere virtuelle Gerätekanäle",
-          "enable_sensors_for_system_variables": "aktiviere Sensoren für Systemvariablen"
+          "enable_virtual_channels": "aktiviere virtuelle Gerätekanäle"
         }
       },
       "interface": {

--- a/custom_components/hahm/translations/en.json
+++ b/custom_components/hahm/translations/en.json
@@ -15,8 +15,7 @@
           "tls": "use TLS",
           "verify_tls": "verify TLS connection",
           "json_port": "JSON-RPC Port",
-          "enable_virtual_channels": "enable virtual channels",
-          "enable_sensors_for_system_variables": "enable sensors for system variables"
+          "enable_virtual_channels": "enable virtual channels"
         }
       },
       "interface": {
@@ -56,8 +55,7 @@
           "tls": "use TLS",
           "verify_tls": "verify TLS connection",
           "json_port": "JSON-RPC Port",
-          "enable_virtual_channels": "enable virtual channels",
-          "enable_sensors_for_system_variables": "enable sensors for system variables"
+          "enable_virtual_channels": "enable virtual channels"
         }
       },
       "interface": {

--- a/custom_components/hahm/translations/nl.json
+++ b/custom_components/hahm/translations/nl.json
@@ -15,8 +15,7 @@
           "json_port": "JSON-RPC poort",
           "tls": "Gebruik TLS",
           "verify_tls": "verifier TLS connection",
-          "enable_virtual_channels": "Virtuele kanalen inschakelen",
-          "enable_sensors_for_system_variables": "Activeer sensoren voor systeemvariabelen"
+          "enable_virtual_channels": "Virtuele kanalen inschakelen"
         }
       },
       "interface": {
@@ -56,8 +55,7 @@
           "json_port": "JSON-RPC poort",
           "tls": "Gebruik TLS",
           "verify_tls": "verifier TLS connection",
-          "enable_virtual_channels": "Virtuele kanalen inschakelen",
-          "enable_sensors_for_system_variables": "Activeer sensoren voor systeemvariabelen"
+          "enable_virtual_channels": "Virtuele kanalen inschakelen"
         }
       },
       "interface": {


### PR DESCRIPTION
- Bump hahomematic to 0.18.0
- Set entity enabled default by entity usage enum
- Remove enable_sensors_for_system_variables from config flow
- Bool SysVars are now binary sensors
- All Sysvars are now disabled by default
- Add instance name to system variable name