### PR TITLE
Fix number entities so they can handle percentages

### DIFF
--- a/custom_components/hahm/number.py
+++ b/custom_components/hahm/number.py
@@ -70,7 +70,7 @@ class HaHomematicNumber(HaHomematicGenericEntity[BaseNumber], NumberEntity):
         super().__init__(control_unit=control_unit, hm_entity=hm_entity)
         self._attr_min_value = hm_entity.min
         self._attr_max_value = hm_entity.max
-        self._attr_step = 1.0 if hm_entity.hmtype == "INTEGER" else 0.1
+        self._attr_step = 1.0 if hm_entity.hmtype == "INTEGER" else 0.01
         self._attr_unit_of_measurement = hm_entity.unit
 
     @property


### PR DESCRIPTION
Changes the decimal accuracy from 0.1 to 0.01 so it can represent percentual values(e.g. Thermostat valve opening state). 
It fixes the warning and let us define percentual values in the number entities.
Fixes [#165](https://github.com/danielperna84/hahomematic/issues/165). 
