### PR TITLE
Bump hahomematic to 0.21.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 0.20.0 (2021-01-13)
+- Bump hahomematic to 0.21.0
+    - Don't exclude Servicemeldungen from sysvars
+    - Use Servicemeldungen sysvar for hub state
+
 Version 0.20.0 (2021-01-12)
 - Bump hahomematic to 0.20.0
 - Fix number entities so they can handle percentages

--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/hahomematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==0.20.0"],
+  "requirements": ["hahomematic==0.21.0"],
   "requirements1": ["git+https://github.com/SukramJ/hahomematic.git@dev1#hahomematic"],
   "ssdp": [],
   "zeroconf": [],
@@ -12,5 +12,5 @@
   "dependencies": [],
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
-  "version": "0.20.0"
+  "version": "0.21.0"
 }


### PR DESCRIPTION
- Bump hahomematic to 0.21.0
    - Don't exclude Servicemeldungen from sysvars
    - Use Servicemeldungen sysvar for hub state