### PR TITLE
Bump hahomematic to 0.23.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.22.3 (2021-01-15)
 - Fix unit of RSSI params
+- Add device class to HM-Sen-RD-O
 
 Version 0.22.2 (2021-01-15)
 - Bump hahomematic to 0.22.2

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
-Version 0.22.3 (2021-01-15)
+Version 0.23.0 (2021-01-16)
+- Bump hahomematic to 0.23.2
+    - Make ["DRY", "RAIN"] sensor a binary_sensor
+    - Add converter to sensor value
+        - HmIP-SCTH230 CONCENTRATION to int
+        - Fix RSSI (experimental)
+    - raise connection_checker interval to 60s
+    - Add sleep interval(120s) to wait with reconnect after successful connection check
 - Fix unit of RSSI params
 - Add device class to HM-Sen-RD-O
 

--- a/custom_components/hahm/entity_helpers.py
+++ b/custom_components/hahm/entity_helpers.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
     PERCENTAGE,
     POWER_WATT,
     PRESSURE_HPA,
-    SIGNAL_STRENGTH_DECIBELS,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     SPEED_KILOMETERS_PER_HOUR,
     TEMP_CELSIUS,
     TIME_MINUTES,
@@ -468,6 +468,10 @@ _BINARY_SENSOR_DESCRIPTIONS_BY_DEVICE_PARAM: dict[
     ("SWDO-PL", "STATE"): BinarySensorEntityDescription(
         key="STATE",
         device_class=BinarySensorDeviceClass.WINDOW,
+    ),
+    ("HM-Sen-RD-O", "STATE"): BinarySensorEntityDescription(
+        key="STATE",
+        device_class=BinarySensorDeviceClass.MOISTURE,
     ),
 }
 

--- a/custom_components/hahm/manifest.json
+++ b/custom_components/hahm/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/hahomematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==0.22.3"],
+  "requirements": ["hahomematic==0.23.2"],
   "requirements1": ["git+https://github.com/SukramJ/hahomematic.git@dev1#hahomematic"],
   "ssdp": [],
   "zeroconf": [],
@@ -12,5 +12,5 @@
   "dependencies": [],
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
-  "version": "0.22.3"
+  "version": "0.23.0"
 }


### PR DESCRIPTION
- Bump hahomematic to 0.23.2
    - Make ["DRY", "RAIN"] sensor a binary_sensor
    - Add converter to sensor value
        - HmIP-SCTH230 CONCENTRATION to int
        - Fix RSSI (experimental)
    - raise connection_checker interval to 60s
    - Add sleep interval(120s) to wait with reconnect after successful connection check
- Add device class to HM-Sen-RD-O