### PR TITLE
HmIP-BSM Kanal 1 und 2

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,7 +3,7 @@ name: Lock
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 5 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,20 @@
+name: Lock
+
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  lock:
+    if: github.repository_owner == 'danielperna84'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4.0.0
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: "30"
+          issue-lock-reason: ""
+          pr-inactive-days: "1"
+          pr-lock-reason: ""

--- a/README.md
+++ b/README.md
@@ -402,8 +402,19 @@ If you want to know how assured the displayed value is, there is an attribute `v
 - `not valid` there is no value. The state of the entity is `unknown`.
 - `restored` the value has been restored from the last saved state after an HA restart
 - `uncertain` the value could not be updated from the CCU after restarting the CCU, and no events were received either.
-- 
+
 If you want to be sure that the state of the entity is as consistent as possible, you should also check the `value_state` attribute for `valid`.
+
+### Sending state changes to backend
+We try to avoid backend calls if value/state doesn't change:
+- If an entity (e.g. `switch`) has only **one** parameter that represents its state, then a call to the backend will be made, 
+  if the parameter value sent is not identical to the current state.
+- If an entity (e.g. `cover`, `climate`, `light`) has **multiple** parameters that represent its state, then a call to the backend will be made, 
+  if one of these parameter values sent is not identical to its current state.
+- Not covered by this approach:
+  - platforms: lock and siren.
+  - services: `stop_cover`, `stop_cover_tilt`, `enable_away_mode_*`, `disable_away_mode`, `set_on_time_value`
+  - system variables
 
 ### Rename of device/channel in CCU not reflected in Home Assistant
 

--- a/README.md
+++ b/README.md
@@ -377,13 +377,13 @@ The `ERROR*` parameters are evaluated for this event type in the backend.
 
 ## Additional information
 
-### What is the meaning of this persistant notification `HOMEMATICIP_LOCAL-XmlRPC-Server received no events`?
+### What is the meaning of this persistent notification `HOMEMATICIP_LOCAL-XmlRPC-Server received no events`?
 This integration does not fetch new updates from the CCU, it **receives** state changes and new values for devices from the CCU by the XmlRPC server.
 
 Therefor the integration checks if this mechanism works:
 
-Regardless of regular device updates, HA checks the availability of the CCU with a `PING` every 15 seconds, and expects a `PONG` event as a response on the XMLRPC server.
-This persistent notification is only displayed in HA if the received PONG events and the device updates are missing for 5 minutes, but it also disappears again as soon as events are received again.
+Regardless of regular device updates, HA checks the availability of the CCU with a `PING` every **15 seconds**, and expects a `PONG` event as a response on the XMLRPC server.
+This persistent notification is only displayed in HA if the received PONG events and the device updates are missing for **10 minutes**, but it also disappears again as soon as events are received again.
 
 So the message means there is a problem in the communication from the CCU to HA that was **identified** by the integration but not **caused**.
 
@@ -561,7 +561,7 @@ The following blueprints can be used to simplify the usage of HomeMatic and Home
 - [Support for 4-button Key Ring Remote Control](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local-actions-for-key_ring_remote_control.yaml): Support for two button remote like HmIP-KRCA.
 - [Support for 6-button Remotes](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local-actions-for-6-button.yaml): Support for two button remote like HmIP-WRC6.
 - [Support for 8-button Remotes](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local-actions-for-8-button.yaml): Support for two button remote like HmIP-RC8.
-- [Support for persistent notifications for unavailable devices](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local_persistent_notification.yaml): Enable persistant notifications about unavailable devices.
+- [Support for persistent notifications for unavailable devices](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local_persistent_notification.yaml): Enable persistent notifications about unavailable devices.
 - [Reactivate device by type](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local_reactivate_device_by_type.yaml). Reactivate unavailable devices by device type.
 - [Reactivate every device](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local_reactivate_device_full.yaml). Reactivate all unavailable devices. NOT recommended. Usage of `by device type` or `single device` should be preferred.
 - [Reactivate single device](https://github.com/danielperna84/custom_homematic/blob/devel/blueprints/automation/homematicip_local_reactivate_single_device.yaml) Reactivate a single unavailable device.

--- a/changelog.md
+++ b/changelog.md
@@ -10,9 +10,10 @@
   - Use cache decorators for some high-traffic methods
   - Allow that channel_no could be None
   - Add and use get_channel_address
+  - Add HmIP-SWSD as siren
 - Add device_class to doorbell if binary behavior is set
 - Align packages to backend lib
-
+- Align to siren backend changes
 
 # Version 1.30.1 (2022-02-08)
 ### New features

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
-# Version 1.28.1 (2022-02-05)
+# Version 1.29.0 (2022-02-06)
 ### New features
 - Add virtual channels for HmIP cover/blind
-- 
+
 ### All changes:
-- Bump hahomematic to 2023.2.3
+- Bump hahomematic to 2023.2.5
   - Add comments to parameter_visibility
   - Use `put_paramset` only when there is more than one parameter to sent
   - Use only one implementation for garage doors (HO/TM)

--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,20 @@
 ### All changes:
 - Bump hahomematic to 2023.2.2
   - Add comments to parameter_visibility
-  - Use put_paramset only when there is more than one parameter to send
+  - Use `put_paramset` only when there is more than one parameter to sent
   - Use only one implementation for garage doors (HO/TM)
+  - Avoid backend calls if value/state doesn't change
+    - If an entity (e.g. `switch`) has only **one** parameter that represents its state, then a call to the backend will be made, 
+      if the parameter value sent is not identical to the current state.
+    - If an entity (e.g. `cover`, `climate`, `light`) has **multiple** parameters that represent its state, then a call to the backend will be made, 
+      if one of these parameter values sent is not identical to its current state.
+    - Not covered by this approach:
+      - platforms: lock and siren.
+      - services: `stop_cover`, `stop_cover_tilt`, `enable_away_mode_*`, `disable_away_mode`, `set_on_time_value`
+      - system variables
+  - Add virtual channels for HmIP cover/blind:
+    - Channel no as examples from HmIP-BROLL. The implementation of the first actor channel (4) remains unchanged, which means that this channel (4) shows the correct cover position from sensor channel (3). 
+      The other actor channels (5+6) are generated as initially deactivated and only use the cover position from their own channel after activation.
 - Fix channel 0 not working for put_paramset
 
 # Version 1.28.0 (2022-02-01)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version 1.30.2 (2022-02-10)
+# Version 1.30.2 (2022-02-11)
 ### New features
 
 ### All changes:
@@ -6,7 +6,7 @@
   - Add project setup script
   - Add entity_data event
   - Add payload mixin
-  - Cleanup packages
+  - Cleanup module dependencies
 - Add device_class to doorbell if binary behavior is set
 - Align packages to backend lib
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 ### New features
 
 ### All changes:
+- Bump hahomematic to 2023.2.9
+  - Fix property types
+  - Ensure modules for platforms are loaded
+  - Use local dicts for device lists
 - Bump hahomematic to 2023.2.8
   - Add project setup script
   - Add entity_data event

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Version 1.30.1 (2022-02-08)
+### New features
+
+### All changes:
+- Bump hahomematic to 2023.2.7
+  - Disable validation of state change for action and button
+  - Check if entity is writable on send
+
 # Version 1.30.0 (2022-02-07)
 ### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ### All changes:
 - Bump hahomematic to 2023.2.2
-  - 
+  - Add comments to parameter_visibility
+  - Use put_paramset only when there is more than one parameter to send
+  - Use only one implementation for garage doors (HO/TM)
 - Fix channel 0 not working for put_paramset
 
 # Version 1.28.0 (2022-02-01)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Version 1.28.1 (2022-02-XX)
-
+### New features
+- Add virtual channels for HmIP cover/blind
+- 
 ### All changes:
 - Bump hahomematic to 2023.2.2
   - Add comments to parameter_visibility

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version 1.30.2 (2022-02-11)
+# Version 1.31.0 (2022-02-13)
 ### New features
 
 ### All changes:
@@ -10,10 +10,17 @@
   - Use cache decorators for some high-traffic methods
   - Allow that channel_no could be None
   - Add and use get_channel_address
-  - Add HmIP-SWSD as siren
+  - Add `HmIP-SWSD` as siren 
 - Add device_class to doorbell if binary behavior is set
 - Align packages to backend lib
 - Align to siren backend changes
+
+# Version 1.30.2 (2022-02-08)
+### All changes:
+- Remove `native_precision` for Concentration of HmIP-SCTH230
+
+This change is necessary because `native_precision` has been swapped for `suggested_display_precision` without a deprecation period in the HA core. Before switching to HA 2023.3, **all** CC users who use version 1.28.0 (or greater) must therefore update.
+Rounding support for Concentration of HmIP-SCTH230 will be readded with HA 2023.3
 
 # Version 1.30.1 (2022-02-08)
 ### New features

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+# Version 1.30.2 (2022-02-10)
+### New features
+
+### All changes:
+- Bump hahomematic to 2023.2.8
+  - Add project setup script
+  - Add entity_data event
+  - Add payload mixin
+  - Cleanup packages
+- Add device_class to doorbell if binary behavior is set
+- Align packages to backend lib
+
+
 # Version 1.30.1 (2022-02-08)
 ### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
   - Add entity_data event
   - Add payload mixin
   - Cleanup module dependencies
+  - Use cache decorators for some high-traffic methods
+  - Allow that channel_no could be None
+  - Add and use get_channel_address
 - Add device_class to doorbell if binary behavior is set
 - Align packages to backend lib
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
   - Add missing bind_collector
   - Add more `Final` typing
   - Add option to collector to disable put_paramset
+  - Add on_time Mixin to temporary store on_time
+- Align to backend lib
 
 # Version 1.29.0 (2022-02-06)
 ### New features

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
-# Version 1.28.1 (2022-02-XX)
+# Version 1.28.1 (2022-02-05)
 ### New features
 - Add virtual channels for HmIP cover/blind
 - 
 ### All changes:
-- Bump hahomematic to 2023.2.2
+- Bump hahomematic to 2023.2.3
   - Add comments to parameter_visibility
   - Use `put_paramset` only when there is more than one parameter to sent
   - Use only one implementation for garage doors (HO/TM)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+# Version 1.30.0 (2022-02-07)
+### New features
+
+### All changes:
+- Bump hahomematic to 2023.2.6
+  - Add missing bind_collector
+  - Add more `Final` typing
+  - Add option to collector to disable put_paramset
+
 # Version 1.29.0 (2022-02-06)
 ### New features
 - Add virtual channels for HmIP cover/blind

--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Homematic(IP) Local from a config entry."""
     min_version = AwesomeVersion(HMIP_LOCAL_MIN_VERSION)
-    if HA_VERSION < min_version:
+    if min_version > HA_VERSION:
         _LOGGER.warning(
             "This release of Homematic(IP) Local requires HA version %s and above",
             HMIP_LOCAL_MIN_VERSION,

--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 import logging
 
 from awesomeversion import AwesomeVersion
-from hahomematic.central_unit import cleanup_cache_dirs
-from hahomematic.helpers import find_free_port
+from hahomematic.support import cleanup_cache_dirs, find_free_port
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, __version__ as HA_VERSION_STR

--- a/custom_components/homematicip_local/binary_sensor.py
+++ b/custom_components/homematicip_local/binary_sensor.py
@@ -5,10 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.binary_sensor import (
-    HmBinarySensor,
-    HmSysvarBinarySensor,
-)
+from hahomematic.generic_platforms.binary_sensor import HmBinarySensor
+from hahomematic.hub_platforms.binary_sensor import HmSysvarBinarySensor
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/binary_sensor.py
+++ b/custom_components/homematicip_local/binary_sensor.py
@@ -5,8 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.binary_sensor import HmBinarySensor
-from hahomematic.hub_platforms.binary_sensor import HmSysvarBinarySensor
+from hahomematic.platforms.generic.binary_sensor import HmBinarySensor
+from hahomematic.platforms.hub.binary_sensor import HmSysvarBinarySensor
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/button.py
+++ b/custom_components/homematicip_local/button.py
@@ -5,7 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.button import HmButton, HmProgramButton
+from hahomematic.generic_platforms.button import HmButton
+from hahomematic.hub_platforms.button import HmProgramButton
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/button.py
+++ b/custom_components/homematicip_local/button.py
@@ -5,8 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.button import HmButton
-from hahomematic.hub_platforms.button import HmProgramButton
+from hahomematic.platforms.generic.button import HmButton
+from hahomematic.platforms.hub.button import HmProgramButton
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/climate.py
+++ b/custom_components/homematicip_local/climate.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.climate import (
+from hahomematic.platforms.custom.climate import (
     HM_PRESET_MODE_PREFIX,
     BaseClimateEntity,
     HmHvacAction,

--- a/custom_components/homematicip_local/config_flow.py
+++ b/custom_components/homematicip_local/config_flow.py
@@ -33,7 +33,7 @@ from hahomematic.const import (
     IF_VIRTUAL_DEVICES_TLS_PORT,
 )
 from hahomematic.exceptions import AuthFailure, NoClients, NoConnection
-from hahomematic.helpers import check_password
+from hahomematic.support import check_password
 import voluptuous as vol
 from voluptuous.schema_builder import UNDEFINED, Schema
 

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -40,8 +40,11 @@ from hahomematic.const import (
     HmInterfaceEventType,
     HmPlatform,
 )
+from hahomematic.custom_platforms.entity import CustomEntity
 from hahomematic.device import HmDevice
-from hahomematic.entity import BaseEntity, CustomEntity, GenericEntity, GenericHubEntity
+from hahomematic.entity import BaseEntity
+from hahomematic.generic_platforms.entity import GenericEntity
+from hahomematic.hub_platforms.entity import GenericHubEntity
 
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, callback
@@ -124,8 +127,7 @@ class BaseControlUnit:
 
     @callback
     def stop_central(self, *args: Any) -> None:
-        """
-        Wrap the call to async_stop.
+        """Wrap the call to async_stop.
 
         Used as an argument to EventBus.async_listen_once.
         """

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -40,11 +40,11 @@ from hahomematic.const import (
     HmInterfaceEventType,
     HmPlatform,
 )
-from hahomematic.custom_platforms.entity import CustomEntity
-from hahomematic.device import HmDevice
-from hahomematic.entity import BaseEntity
-from hahomematic.generic_platforms.entity import GenericEntity
-from hahomematic.hub_platforms.entity import GenericHubEntity
+from hahomematic.platforms.custom.entity import CustomEntity
+from hahomematic.platforms.device import HmDevice
+from hahomematic.platforms.entity import BaseEntity
+from hahomematic.platforms.generic.entity import GenericEntity
+from hahomematic.platforms.hub.entity import GenericHubEntity
 
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, callback

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -651,7 +651,7 @@ class ControlUnitTemp(BaseControlUnit):
 
     async def async_stop_central(self) -> None:
         """Stop the control unit."""
-        await self.central.clear_all()
+        await self.central.clear_all_caches()
         await super().async_stop_central()
 
 
@@ -762,7 +762,9 @@ class HmScheduler:
             "Scheduled fetching of master entities for %s",
             self._central.name,
         )
-        await self._central.refresh_entity_data(paramset_key=PARAMSET_KEY_MASTER)
+        await self._central.load_and_refresh_entity_data(
+            paramset_key=PARAMSET_KEY_MASTER
+        )
 
 
 def async_signal_new_hm_entity(entry_id: str, platform: HmPlatform) -> str:

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -406,7 +406,7 @@ class ControlUnit(BaseControlUnit):
                 new_entities.extend(device.custom_entities.values())
 
             # Handle event of new device creation in Homematic(IP) Local.
-            for (platform, hm_entities) in self.async_get_new_hm_entities(
+            for platform, hm_entities in self.async_get_new_hm_entities(
                 new_entities=new_entities
             ).items():
                 if hm_entities and len(hm_entities) > 0:
@@ -435,7 +435,7 @@ class ControlUnit(BaseControlUnit):
             if self._scheduler and self._scheduler.sysvar_scan_enabled:
                 new_hub_entities = kwargs["new_hub_entities"]
                 # Handle event of new hub entity creation in Homematic(IP) Local.
-                for (platform, hm_hub_entities) in self.async_get_new_hm_hub_entities(
+                for platform, hm_hub_entities in self.async_get_new_hm_hub_entities(
                     new_hub_entities=new_hub_entities
                 ).items():
                     if hm_hub_entities and len(hm_hub_entities) > 0:

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 from hahomematic.central_unit import CentralConfig, CentralUnit
 from hahomematic.client import InterfaceConfig
-from hahomematic.config import CHECK_INTERVAL
+from hahomematic.config import CALLBACK_WARN_INTERVAL
 from hahomematic.const import (
     ATTR_ADDRESS,
     ATTR_CALLBACK_HOST,
@@ -484,7 +484,7 @@ class ControlUnit(BaseControlUnit):
                         identifier=f"callback-{interface_id}",
                         title=title,
                         message=f"No callback events received for interface "
-                        f"{interface_id} {CHECK_INTERVAL}s.",
+                        f"{interface_id} {CALLBACK_WARN_INTERVAL}s.",
                     )
         else:
             device_address = event_data[ATTR_ADDRESS]

--- a/custom_components/homematicip_local/cover.py
+++ b/custom_components/homematicip_local/cover.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, TypeVar
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.cover import BaseGarage, CeBlind, CeCover, CeIpBlind
+from hahomematic.custom_platforms.cover import CeGarage, CeBlind, CeCover, CeIpBlind
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
@@ -26,7 +26,7 @@ from .generic_entity import HaHomematicGenericRestoreEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-HmBaseCoverEntity = CeCover | BaseGarage
+HmBaseCoverEntity = CeCover | CeGarage
 HmGenericCover = TypeVar("HmGenericCover", bound=HmBaseCoverEntity)
 
 
@@ -56,7 +56,7 @@ async def async_setup_entry(
                 entities.append(HaHomematicBlind(control_unit, hm_entity))
             elif isinstance(hm_entity, CeCover):
                 entities.append(HaHomematicCover(control_unit, hm_entity))
-            elif isinstance(hm_entity, BaseGarage):
+            elif isinstance(hm_entity, CeGarage):
                 entities.append(HaHomematicGarage(control_unit, hm_entity))
 
         if entities:
@@ -167,5 +167,5 @@ class HaHomematicBlind(HaHomematicBaseCover[CeBlind | CeIpBlind]):
         await self._hm_entity.stop_cover_tilt()
 
 
-class HaHomematicGarage(HaHomematicBaseCover[BaseGarage]):
+class HaHomematicGarage(HaHomematicBaseCover[CeGarage]):
     """Representation of the HomematicIP garage entity."""

--- a/custom_components/homematicip_local/cover.py
+++ b/custom_components/homematicip_local/cover.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, TypeVar
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.cover import CeGarage, CeBlind, CeCover, CeIpBlind
+from hahomematic.custom_platforms.cover import CeBlind, CeCover, CeGarage, CeIpBlind
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,

--- a/custom_components/homematicip_local/cover.py
+++ b/custom_components/homematicip_local/cover.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, TypeVar
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.cover import CeBlind, CeCover, CeGarage, CeIpBlind
+from hahomematic.platforms.custom.cover import CeBlind, CeCover, CeGarage, CeIpBlind
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,

--- a/custom_components/homematicip_local/device_action.py
+++ b/custom_components/homematicip_local/device_action.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from typing import Any
 
 from hahomematic.const import EVENT_PRESS_LONG, EVENT_PRESS_SHORT
-from hahomematic.generic_platforms.action import HmAction
-from hahomematic.generic_platforms.button import HmButton
+from hahomematic.platforms.generic.action import HmAction
+from hahomematic.platforms.generic.button import HmButton
 import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE

--- a/custom_components/homematicip_local/device_trigger.py
+++ b/custom_components/homematicip_local/device_trigger.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from hahomematic.const import CLICK_EVENTS, HmEntityUsage
-from hahomematic.entity import ClickEvent
+from hahomematic.event import ClickEvent
 import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA

--- a/custom_components/homematicip_local/device_trigger.py
+++ b/custom_components/homematicip_local/device_trigger.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from hahomematic.const import CLICK_EVENTS, HmEntityUsage
-from hahomematic.event import ClickEvent
+from hahomematic.platforms.event import ClickEvent
 import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA

--- a/custom_components/homematicip_local/entity_helpers.py
+++ b/custom_components/homematicip_local/entity_helpers.py
@@ -5,10 +5,10 @@ import logging
 from typing import Final
 
 from hahomematic.const import HmPlatform
-from hahomematic.helpers import element_matches_key
 from hahomematic.platforms.custom.entity import CustomEntity
 from hahomematic.platforms.generic.entity import GenericEntity, WrapperEntity
 from hahomematic.platforms.hub.entity import GenericHubEntity
+from hahomematic.support import element_matches_key
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/custom_components/homematicip_local/entity_helpers.py
+++ b/custom_components/homematicip_local/entity_helpers.py
@@ -5,10 +5,10 @@ import logging
 from typing import Final
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.entity import CustomEntity
-from hahomematic.generic_platforms.entity import GenericEntity, WrapperEntity
 from hahomematic.helpers import element_matches_key
-from hahomematic.hub_platforms.entity import GenericHubEntity
+from hahomematic.platforms.custom.entity import CustomEntity
+from hahomematic.platforms.generic.entity import GenericEntity, WrapperEntity
+from hahomematic.platforms.hub.entity import GenericHubEntity
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/custom_components/homematicip_local/entity_helpers.py
+++ b/custom_components/homematicip_local/entity_helpers.py
@@ -5,13 +5,10 @@ import logging
 from typing import Final
 
 from hahomematic.const import HmPlatform
-from hahomematic.entity import (
-    CustomEntity,
-    GenericEntity,
-    GenericHubEntity,
-    WrapperEntity,
-)
+from hahomematic.custom_platforms.entity import CustomEntity
+from hahomematic.generic_platforms.entity import GenericEntity, WrapperEntity
 from hahomematic.helpers import element_matches_key
+from hahomematic.hub_platforms.entity import GenericHubEntity
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -530,6 +527,10 @@ _BINARY_SENSOR_DESCRIPTIONS_BY_PARAM: dict[str | tuple[str, ...], EntityDescript
 _BINARY_SENSOR_DESCRIPTIONS_BY_DEVICE_AND_PARAM: dict[
     tuple[str | tuple[str, ...], str], EntityDescription
 ] = {
+    ("HmIP-DSD-PCB", "STATE"): BinarySensorEntityDescription(
+        key="STATE",
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
+    ),
     (
         ("HmIP-SCI", "HmIP-FCI1", "HmIP-FCI6"),
         "STATE",

--- a/custom_components/homematicip_local/entity_helpers.py
+++ b/custom_components/homematicip_local/entity_helpers.py
@@ -19,6 +19,7 @@ from homeassistant.components.cover import CoverDeviceClass, CoverEntityDescript
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.components.siren import SirenEntityDescription
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntityDescription
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -598,6 +599,13 @@ _COVER_DESCRIPTIONS_BY_DEVICE: dict[str | tuple[str, ...], EntityDescription] = 
     ),
 }
 
+_SIREN_DESCRIPTIONS_BY_DEVICE: dict[str | tuple[str, ...], EntityDescription] = {
+    "HmIP-SWSD": SirenEntityDescription(
+        key="SWSD",
+        entity_registry_enabled_default=False,
+    ),
+}
+
 _SWITCH_DESCRIPTIONS_BY_DEVICE: dict[str | tuple[str, ...], EntityDescription] = {
     "HmIP-PS": SwitchEntityDescription(
         key="OUTLET",
@@ -623,6 +631,7 @@ _ENTITY_DESCRIPTION_BY_DEVICE: dict[
     HmPlatform, dict[str | tuple[str, ...], EntityDescription]
 ] = {
     HmPlatform.COVER: _COVER_DESCRIPTIONS_BY_DEVICE,
+    HmPlatform.SIREN: _SIREN_DESCRIPTIONS_BY_DEVICE,
     HmPlatform.SWITCH: _SWITCH_DESCRIPTIONS_BY_DEVICE,
 }
 

--- a/custom_components/homematicip_local/entity_helpers.py
+++ b/custom_components/homematicip_local/entity_helpers.py
@@ -73,7 +73,10 @@ _NUMBER_DESCRIPTIONS_BY_PARAM: dict[str | tuple[str, ...], EntityDescription] = 
 _NUMBER_DESCRIPTIONS_BY_DEVICE_AND_PARAM: dict[
     tuple[str | tuple[str, ...], str], EntityDescription
 ] = {
-    (("HmIP-eTRV", "HmIP-HEATING"), "LEVEL",): HmNumberEntityDescription(
+    (
+        ("HmIP-eTRV", "HmIP-HEATING"),
+        "LEVEL",
+    ): HmNumberEntityDescription(
         key="LEVEL",
         icon="mdi:pipe-valve",
         multiplier=100,
@@ -394,7 +397,10 @@ _SENSOR_DESCRIPTIONS_BY_DEVICE_AND_PARAM: dict[
         icon="mdi:lock-alert",
         translation_key="sec_key_error",
     ),
-    (("HmIP-eTRV", "HmIP-HEATING"), "LEVEL",): HmSensorEntityDescription(
+    (
+        ("HmIP-eTRV", "HmIP-HEATING"),
+        "LEVEL",
+    ): HmSensorEntityDescription(
         key="LEVEL",
         icon="mdi:pipe-valve",
         native_unit_of_measurement=PERCENTAGE,
@@ -525,7 +531,10 @@ _BINARY_SENSOR_DESCRIPTIONS_BY_PARAM: dict[str | tuple[str, ...], EntityDescript
 _BINARY_SENSOR_DESCRIPTIONS_BY_DEVICE_AND_PARAM: dict[
     tuple[str | tuple[str, ...], str], EntityDescription
 ] = {
-    (("HmIP-SCI", "HmIP-FCI1", "HmIP-FCI6"), "STATE",): BinarySensorEntityDescription(
+    (
+        ("HmIP-SCI", "HmIP-FCI1", "HmIP-FCI6"),
+        "STATE",
+    ): BinarySensorEntityDescription(
         key="STATE",
         device_class=BinarySensorDeviceClass.OPENING,
     ),

--- a/custom_components/homematicip_local/entity_helpers.py
+++ b/custom_components/homematicip_local/entity_helpers.py
@@ -111,7 +111,6 @@ _SENSOR_DESCRIPTIONS_BY_PARAM: dict[str | tuple[str, ...], EntityDescription] = 
     "CONCENTRATION": HmSensorEntityDescription(
         key="CONCENTRATION",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
-        native_precision=0,
         device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/custom_components/homematicip_local/generic_entity.py
+++ b/custom_components/homematicip_local/generic_entity.py
@@ -5,14 +5,10 @@ import logging
 from typing import Any, Generic, cast
 
 from hahomematic.const import HmCallSource
-from hahomematic.entity import (
-    CallbackEntity,
-    CustomEntity,
-    GenericEntity,
-    GenericHubEntity,
-    GenericSystemVariable,
-    WrapperEntity,
-)
+from hahomematic.custom_platforms.entity import CustomEntity
+from hahomematic.entity import CallbackEntity
+from hahomematic.generic_platforms.entity import GenericEntity, WrapperEntity
+from hahomematic.hub_platforms.entity import GenericHubEntity, GenericSystemVariable
 
 from homeassistant.core import State, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er

--- a/custom_components/homematicip_local/generic_entity.py
+++ b/custom_components/homematicip_local/generic_entity.py
@@ -5,10 +5,10 @@ import logging
 from typing import Any, Generic, cast
 
 from hahomematic.const import HmCallSource
-from hahomematic.custom_platforms.entity import CustomEntity
-from hahomematic.entity import CallbackEntity
-from hahomematic.generic_platforms.entity import GenericEntity, WrapperEntity
-from hahomematic.hub_platforms.entity import GenericHubEntity, GenericSystemVariable
+from hahomematic.platforms.custom.entity import CustomEntity
+from hahomematic.platforms.entity import CallbackEntity
+from hahomematic.platforms.generic.entity import GenericEntity, WrapperEntity
+from hahomematic.platforms.hub.entity import GenericHubEntity, GenericSystemVariable
 
 from homeassistant.core import State, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er

--- a/custom_components/homematicip_local/helpers.py
+++ b/custom_components/homematicip_local/helpers.py
@@ -9,10 +9,10 @@ import logging
 from typing import Any, TypeVar
 
 from hahomematic.const import ATTR_CHANNEL_NO, ATTR_PARAMETER, ATTR_VALUE
-from hahomematic.custom_platforms.entity import CustomEntity
-from hahomematic.entity import HM_EVENT_SCHEMA
-from hahomematic.generic_platforms.entity import GenericEntity, WrapperEntity
-from hahomematic.hub_platforms.entity import GenericHubEntity
+from hahomematic.platforms.custom.entity import CustomEntity
+from hahomematic.platforms.entity import HM_EVENT_SCHEMA
+from hahomematic.platforms.generic.entity import GenericEntity, WrapperEntity
+from hahomematic.platforms.hub.entity import GenericHubEntity
 import voluptuous as vol
 
 from homeassistant.components.number import NumberEntityDescription

--- a/custom_components/homematicip_local/helpers.py
+++ b/custom_components/homematicip_local/helpers.py
@@ -9,13 +9,10 @@ import logging
 from typing import Any, TypeVar
 
 from hahomematic.const import ATTR_CHANNEL_NO, ATTR_PARAMETER, ATTR_VALUE
-from hahomematic.entity import (
-    HM_EVENT_SCHEMA,
-    CustomEntity,
-    GenericEntity,
-    GenericHubEntity,
-    WrapperEntity,
-)
+from hahomematic.custom_platforms.entity import CustomEntity
+from hahomematic.entity import HM_EVENT_SCHEMA
+from hahomematic.generic_platforms.entity import GenericEntity, WrapperEntity
+from hahomematic.hub_platforms.entity import GenericHubEntity
 import voluptuous as vol
 
 from homeassistant.components.number import NumberEntityDescription

--- a/custom_components/homematicip_local/light.py
+++ b/custom_components/homematicip_local/light.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.light import (
+from hahomematic.platforms.custom.light import (
     HM_ARG_COLOR_TEMP,
     HM_ARG_EFFECT,
     HM_ARG_HS_COLOR,

--- a/custom_components/homematicip_local/light.py
+++ b/custom_components/homematicip_local/light.py
@@ -232,6 +232,7 @@ class HaHomematicLight(HaHomematicGenericRestoreEntity[BaseHmLight], LightEntity
             hm_kwargs[HM_ARG_RAMP_TIME] = ramp_time
         await self._hm_entity.turn_off(**hm_kwargs)
 
-    async def async_set_on_time(self, on_time: float) -> None:
+    @callback
+    def async_set_on_time(self, on_time: float) -> None:
         """Set the on time of the light."""
-        await self._hm_entity.set_on_time_value(on_time=on_time)
+        self._hm_entity.set_on_time(on_time=on_time)

--- a/custom_components/homematicip_local/lock.py
+++ b/custom_components/homematicip_local/lock.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.lock import LOCK_STATE_LOCKED, BaseLock
+from hahomematic.platforms.custom.lock import LOCK_STATE_LOCKED, BaseLock
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -17,6 +17,6 @@
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
   "loggers": ["hahomematic"],
-  "version": "1.30.2",
+  "version": "1.31.0",
   "integration_type": "hub"
 }

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/custom_homematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==2023.2.8"],
+  "requirements": ["hahomematic==2023.2.9"],
   "ssdp": [
     {
       "manufacturer": "EQ3",

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/custom_homematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==2023.2.2"],
+  "requirements": ["hahomematic==2023.2.3"],
   "ssdp": [
     {
       "manufacturer": "EQ3",

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/custom_homematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==2023.2.7"],
+  "requirements": ["hahomematic==2023.2.8"],
   "ssdp": [
     {
       "manufacturer": "EQ3",
@@ -17,6 +17,6 @@
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
   "loggers": ["hahomematic"],
-  "version": "1.30.1",
+  "version": "1.30.2",
   "integration_type": "hub"
 }

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/custom_homematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==2023.2.5"],
+  "requirements": ["hahomematic==2023.2.6"],
   "ssdp": [
     {
       "manufacturer": "EQ3",
@@ -17,6 +17,6 @@
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
   "loggers": ["hahomematic"],
-  "version": "1.29.0",
+  "version": "1.30.0",
   "integration_type": "hub"
 }

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/custom_homematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==2023.2.3"],
+  "requirements": ["hahomematic==2023.2.5"],
   "ssdp": [
     {
       "manufacturer": "EQ3",
@@ -17,6 +17,6 @@
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
   "loggers": ["hahomematic"],
-  "version": "1.28.1",
+  "version": "1.29.0",
   "integration_type": "hub"
 }

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/danielperna84/custom_homematic",
   "issue_tracker": "https://github.com/danielperna84/hahomematic/issues",
-  "requirements": ["hahomematic==2023.2.6"],
+  "requirements": ["hahomematic==2023.2.7"],
   "ssdp": [
     {
       "manufacturer": "EQ3",
@@ -17,6 +17,6 @@
   "codeowners": ["@danielperna84", "@SukramJ"],
   "iot_class": "local_push",
   "loggers": ["hahomematic"],
-  "version": "1.30.0",
+  "version": "1.30.1",
   "integration_type": "hub"
 }

--- a/custom_components/homematicip_local/number.py
+++ b/custom_components/homematicip_local/number.py
@@ -5,8 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import SYSVAR_HM_TYPE_FLOAT, SYSVAR_HM_TYPE_INTEGER, HmPlatform
-from hahomematic.generic_platforms.number import BaseNumber
-from hahomematic.hub_platforms.number import HmSysvarNumber
+from hahomematic.platforms.generic.number import BaseNumber
+from hahomematic.platforms.hub.number import HmSysvarNumber
 
 from homeassistant.components.number import NumberEntity, NumberMode, RestoreNumber
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/number.py
+++ b/custom_components/homematicip_local/number.py
@@ -5,7 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import SYSVAR_HM_TYPE_FLOAT, SYSVAR_HM_TYPE_INTEGER, HmPlatform
-from hahomematic.generic_platforms.number import BaseNumber, HmSysvarNumber
+from hahomematic.generic_platforms.number import BaseNumber
+from hahomematic.hub_platforms.number import HmSysvarNumber
 
 from homeassistant.components.number import NumberEntity, NumberMode, RestoreNumber
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/select.py
+++ b/custom_components/homematicip_local/select.py
@@ -5,8 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.select import HmSelect
-from hahomematic.hub_platforms.select import HmSysvarSelect
+from hahomematic.platforms.generic.select import HmSelect
+from hahomematic.platforms.hub.select import HmSysvarSelect
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/select.py
+++ b/custom_components/homematicip_local/select.py
@@ -5,7 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.select import HmSelect, HmSysvarSelect
+from hahomematic.generic_platforms.select import HmSelect
+from hahomematic.hub_platforms.select import HmSysvarSelect
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/sensor.py
+++ b/custom_components/homematicip_local/sensor.py
@@ -139,7 +139,7 @@ class HaHomematicSensor(HaHomematicGenericEntity[HmSensor], RestoreSensor):
                 and self._hm_entity.hmtype in (TYPE_FLOAT, TYPE_INTEGER)
                 and self._multiplier != 1
             ):
-                return self._hm_entity.value * self._multiplier
+                return self._hm_entity.value * self._multiplier  # type: ignore[no-any-return]
             # Strings and enums with custom device class must be lowercase
             # to be translatable.
             if (
@@ -147,10 +147,10 @@ class HaHomematicSensor(HaHomematicGenericEntity[HmSensor], RestoreSensor):
                 and self.translation_key is not None
                 and self._hm_entity.hmtype in (TYPE_ENUM, TYPE_STRING)
             ):
-                return self._hm_entity.value.lower()
+                return self._hm_entity.value.lower()  # type: ignore[no-any-return]
             return self._hm_entity.value
         if self.is_restored:
-            return self._restored_native_value
+            return self._restored_native_value  # type: ignore[no-any-return]
         return None
 
     @property

--- a/custom_components/homematicip_local/sensor.py
+++ b/custom_components/homematicip_local/sensor.py
@@ -16,7 +16,8 @@ from hahomematic.const import (
     TYPE_STRING,
     HmPlatform,
 )
-from hahomematic.generic_platforms.sensor import HmSensor, HmSysvarSensor
+from hahomematic.generic_platforms.sensor import HmSensor
+from hahomematic.hub_platforms.sensor import HmSysvarSensor
 
 from homeassistant.components.sensor import (
     RestoreSensor,

--- a/custom_components/homematicip_local/sensor.py
+++ b/custom_components/homematicip_local/sensor.py
@@ -16,8 +16,8 @@ from hahomematic.const import (
     TYPE_STRING,
     HmPlatform,
 )
-from hahomematic.generic_platforms.sensor import HmSensor
-from hahomematic.hub_platforms.sensor import HmSysvarSensor
+from hahomematic.platforms.generic.sensor import HmSensor
+from hahomematic.platforms.hub.sensor import HmSysvarSensor
 
 from homeassistant.components.sensor import (
     RestoreSensor,

--- a/custom_components/homematicip_local/sensor.py
+++ b/custom_components/homematicip_local/sensor.py
@@ -139,7 +139,7 @@ class HaHomematicSensor(HaHomematicGenericEntity[HmSensor], RestoreSensor):
                 and self._hm_entity.hmtype in (TYPE_FLOAT, TYPE_INTEGER)
                 and self._multiplier != 1
             ):
-                return self._hm_entity.value * self._multiplier  # type: ignore[no-any-return]
+                return self._hm_entity.value * self._multiplier
             # Strings and enums with custom device class must be lowercase
             # to be translatable.
             if (
@@ -147,10 +147,10 @@ class HaHomematicSensor(HaHomematicGenericEntity[HmSensor], RestoreSensor):
                 and self.translation_key is not None
                 and self._hm_entity.hmtype in (TYPE_ENUM, TYPE_STRING)
             ):
-                return self._hm_entity.value.lower()  # type: ignore[no-any-return]
+                return self._hm_entity.value.lower()
             return self._hm_entity.value
         if self.is_restored:
-            return self._restored_native_value  # type: ignore[no-any-return]
+            return self._restored_native_value
         return None
 
     @property

--- a/custom_components/homematicip_local/services.py
+++ b/custom_components/homematicip_local/services.py
@@ -13,8 +13,8 @@ from hahomematic.const import (
     PARAMSET_KEY_VALUES,
     HmForcedDeviceAvailability,
 )
-from hahomematic.device import HmDevice
 from hahomematic.helpers import to_bool
+from hahomematic.platforms.device import HmDevice
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_MODE, ATTR_TIME

--- a/custom_components/homematicip_local/services.py
+++ b/custom_components/homematicip_local/services.py
@@ -442,7 +442,7 @@ async def _async_service_clear_cache(hass: HomeAssistant, service: ServiceCall) 
     """Service to clear the cache."""
     entry_id = service.data[ATTR_ENTRY_ID]
     if control := _get_control_unit(hass=hass, entry_id=entry_id):
-        await control.central.clear_all()
+        await control.central.clear_all_caches()
 
 
 async def _async_service_fetch_system_variables(

--- a/custom_components/homematicip_local/services.py
+++ b/custom_components/homematicip_local/services.py
@@ -13,8 +13,8 @@ from hahomematic.const import (
     PARAMSET_KEY_VALUES,
     HmForcedDeviceAvailability,
 )
-from hahomematic.helpers import to_bool
 from hahomematic.platforms.device import HmDevice
+from hahomematic.support import to_bool
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_MODE, ATTR_TIME

--- a/custom_components/homematicip_local/siren.py
+++ b/custom_components/homematicip_local/siren.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.siren import (
+from hahomematic.platforms.custom.siren import (
     DISABLE_ACOUSTIC_SIGNAL,
     DISABLE_OPTICAL_SIGNAL,
     BaseSiren,

--- a/custom_components/homematicip_local/switch.py
+++ b/custom_components/homematicip_local/switch.py
@@ -6,7 +6,8 @@ from typing import Any
 
 from hahomematic.const import HmPlatform
 from hahomematic.custom_platforms.switch import CeSwitch
-from hahomematic.generic_platforms.switch import HmSwitch, HmSysvarSwitch
+from hahomematic.generic_platforms.switch import HmSwitch
+from hahomematic.hub_platforms.switch import HmSysvarSwitch
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity

--- a/custom_components/homematicip_local/switch.py
+++ b/custom_components/homematicip_local/switch.py
@@ -5,9 +5,9 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.custom_platforms.switch import CeSwitch
-from hahomematic.generic_platforms.switch import HmSwitch
-from hahomematic.hub_platforms.switch import HmSysvarSwitch
+from hahomematic.platforms.custom.switch import CeSwitch
+from hahomematic.platforms.generic.switch import HmSwitch
+from hahomematic.platforms.hub.switch import HmSysvarSwitch
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity

--- a/custom_components/homematicip_local/switch.py
+++ b/custom_components/homematicip_local/switch.py
@@ -138,7 +138,10 @@ class HaHomematicSwitch(
 
     async def async_set_on_time(self, on_time: float) -> None:
         """Set the on time of the light."""
-        await self._hm_entity.set_on_time_value(on_time=on_time)
+        if isinstance(self._hm_entity, CeSwitch):
+            self._hm_entity.set_on_time(on_time=on_time)
+        if isinstance(self._hm_entity, HmSwitch):
+            await self._hm_entity.set_on_time(on_time=on_time)
 
 
 class HaHomematicSysvarSwitch(

--- a/custom_components/homematicip_local/text.py
+++ b/custom_components/homematicip_local/text.py
@@ -5,8 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.text import HmText
-from hahomematic.hub_platforms.text import HmSysvarText
+from hahomematic.platforms.generic.text import HmText
+from hahomematic.platforms.hub.text import HmSysvarText
 
 from homeassistant.components.text import TextEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/homematicip_local/text.py
+++ b/custom_components/homematicip_local/text.py
@@ -5,7 +5,8 @@ import logging
 from typing import Any
 
 from hahomematic.const import HmPlatform
-from hahomematic.generic_platforms.text import HmSysvarText, HmText
+from hahomematic.generic_platforms.text import HmText
+from hahomematic.hub_platforms.text import HmSysvarText
 
 from homeassistant.components.text import TextEntity
 from homeassistant.config_entries import ConfigEntry


### PR DESCRIPTION
Ich nutze den HmIP-BSM als Schalter, was unter HA wunderbar funktioniert. Jedoch bekomme ich meine zweite Anforderung nicht umgesetzt. Der HmIP-BSM soll auch als Taster fungieren um eine andere Aktion zu triggern. Bei einem HmIP-BRC2 werden die Kanäle 1 und 2 an HA weitergegeben, so dass ich diese in HA abfragen kann. Beim HmIP-BSM werden die entsprechenden Kanäle 1 und 2 jedoch nicht an HA weiter gereicht. Kann dies bitte korrigiert werden?