### PR TITLE
Add simplified schedule services for climate profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,52 +781,6 @@ Returns a paramset
 Call to `getParamset` for direct connections on the XML-RPC interface.
 Returns a paramset
 
-### `homematicip_local.get_schedule_profile`
-
-Returns the schedule of a climate profile (e.g., P1, P2, etc.).
-
-**Return format:** The returned data contains all weekdays for the specified profile. Redundant 24:00 slots are automatically filtered out, so you typically receive only the meaningful time slots (usually 3-7 slots instead of 13).
-
-**Example structure:**
-```yaml
-MONDAY:
-  1:
-    ENDTIME: "06:00"
-    TEMPERATURE: 18.0
-  2:
-    ENDTIME: "22:00"
-    TEMPERATURE: 21.0
-  3:
-    ENDTIME: "24:00"
-    TEMPERATURE: 18.0
-TUESDAY:
-  ...
-```
-
-### `homematicip_local.get_schedule_weekday`
-
-Returns the schedule of a climate profile for a specific weekday.
-
-**Return format:** The returned data is filtered to show only meaningful slots. Redundant 24:00 slots at the end are removed automatically. Each slot defines a temperature period that ends at the specified ENDTIME.
-
-**Example structure:**
-```yaml
-1:
-  ENDTIME: "06:00"
-  TEMPERATURE: 18.0
-2:
-  ENDTIME: "08:00"
-  TEMPERATURE: 21.0
-3:
-  ENDTIME: "24:00"
-  TEMPERATURE: 18.0
-```
-
-**Understanding slots:**
-- Slot 1 means: From 00:00 until 06:00, maintain 18.0°C
-- Slot 2 means: From 06:00 until 08:00, maintain 21.0°C
-- Slot 3 means: From 08:00 until 24:00, maintain 18.0°C
-
 ### `homematicip_local.put_paramset`
 
 __Disclaimer: Too much writing to the device MASTER paramset could kill your device's storage.__
@@ -920,7 +874,60 @@ This creates:
 - 17:00-22:00: 21.0°C (your second period)
 - 22:00-24:00: 18.0°C (base_temperature)
 
-See the [sample](#sample-for-set_schedule_simple_weekday) below for a complete example. 
+See the [sample](#sample-for-set_schedule_simple_weekday) below for a complete example.
+
+### `homematicip_local.get_schedule_simple_profile`
+
+Returns the schedule of a climate profile in a **simplified format**.
+
+**How it works:** The service analyzes the schedule and automatically determines the `base_temperature` as the most frequently used temperature throughout the day. Only time periods that deviate from this base temperature are returned as `periods`. This makes the schedule much easier to read and understand.
+
+**Return format:** The returned data contains all weekdays for the specified profile. Each weekday has a `base_temperature` and a list of `periods` with `starttime`, `endtime`, and `temperature`.
+
+**Example structure:**
+```yaml
+MONDAY:
+  base_temperature: 18.0
+  periods:
+    - starttime: "06:00"
+      endtime: "08:00"
+      temperature: 21.0
+    - starttime: "17:00"
+      endtime: "22:00"
+      temperature: 21.0
+TUESDAY:
+  base_temperature: 18.0
+  periods:
+    - starttime: "06:00"
+      endtime: "22:00"
+      temperature: 21.0
+# ... other weekdays
+```
+
+### `homematicip_local.get_schedule_simple_weekday`
+
+Returns the schedule of a climate profile for a specific weekday in a **simplified format**.
+
+**How it works:** The service analyzes the weekday schedule and determines the `base_temperature` as the most frequently used temperature. Only time periods with temperatures that differ from the base are returned as `periods`, keeping the output compact and readable.
+
+**Return format:** The returned data contains the `base_temperature` and a list of `periods` for the specified weekday.
+
+**Example structure:**
+```yaml
+base_temperature: 18.0
+periods:
+  - starttime: "06:00"
+    endtime: "08:00"
+    temperature: 21.0
+  - starttime: "17:00"
+    endtime: "22:00"
+    temperature: 21.0
+```
+
+**Understanding the format:**
+- `base_temperature`: The default temperature used for all times not covered by periods
+- `periods`: List of heating/cooling periods with start time, end time, and target temperature
+- Times are in 24-hour format ("HH:MM")
 
 ### `homematicip_local.get_variable_value`
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,13 @@
 
 ## What's Changed
 
+### New Features
+
+- **Simple Schedule Services**: Added `get_schedule_simple_profile` and `get_schedule_simple_weekday` services. These return schedule data in a simplified format that is easier to read and use.
+
 ### Deprecations
 
-- **Schedule Services**: Deprecated `set_schedule_profile` and `set_schedule_weekday` services. These will be removed in April 2026. Use `set_schedule_simple_profile` and `set_schedule_simple_weekday` instead. A warning is now logged when using the deprecated services.
+- **Schedule Services**: Deprecated `set_schedule_profile`, `set_schedule_weekday`, `get_schedule_profile`, and `get_schedule_weekday` services. These will be removed in April 2026. Use `set_schedule_simple_profile`, `set_schedule_simple_weekday`, `get_schedule_simple_profile`, and `get_schedule_simple_weekday` instead. A warning is now logged when using the deprecated services.
 
 ## Bump aiohomematic to [2026.1.11](https://github.com/SukramJ/aiohomematic/compare/2026.1.9...2026.1.11)
 

--- a/custom_components/homematicip_local/climate.py
+++ b/custom_components/homematicip_local/climate.py
@@ -323,16 +323,30 @@ class AioHomematicClimate(AioHomematicGenericRestoreEntity[BaseCustomDpClimate],
     @handle_homematic_errors
     async def async_get_schedule_profile(self, profile: str | ScheduleProfile) -> ServiceResponse:
         """Get a schedule profile."""
+        _LOGGER.warning("Service 'get_schedule_profile' is deprecated and will be removed in April 2026. ")
         schedule_profile = profile if isinstance(profile, ScheduleProfile) else ScheduleProfile(profile)
         if profile_data := await self._data_point.get_schedule_profile(profile=schedule_profile):
             return cast(ServiceResponse, profile_data)
         return None
 
     @handle_homematic_errors
+    async def async_get_schedule_simple_profile(self, profile: ScheduleProfile) -> ServiceResponse:
+        """Get a schedule simple profile."""
+        return cast(ServiceResponse, await self._data_point.get_schedule_simple_profile(profile=profile))
+
+    @handle_homematic_errors
+    async def async_get_schedule_simple_weekday(self, profile: ScheduleProfile, weekday: WeekdayStr) -> ServiceResponse:
+        """Get a schedule simple profile weekday."""
+        return cast(
+            ServiceResponse, await self._data_point.get_schedule_simple_weekday(profile=profile, weekday=weekday)
+        )
+
+    @handle_homematic_errors
     async def async_get_schedule_weekday(
         self, profile: str | ScheduleProfile, weekday: str | WeekdayStr
     ) -> ServiceResponse:
         """Get a schedule profile weekday."""
+        _LOGGER.warning("Service 'get_schedule_weekday' is deprecated and will be removed in April 2026.")
         schedule_profile = profile if isinstance(profile, ScheduleProfile) else ScheduleProfile(profile)
         schedule_weekday = weekday if isinstance(weekday, WeekdayStr) else WeekdayStr(weekday)
         if weekday_data := await self._data_point.get_schedule_weekday(

--- a/custom_components/homematicip_local/const.py
+++ b/custom_components/homematicip_local/const.py
@@ -98,6 +98,8 @@ class HmipLocalServices(StrEnum):
     GET_LINK_PEERS = "get_link_peers"
     GET_PARAMSET = "get_paramset"
     GET_SCHEDULE_PROFILE = "get_schedule_profile"
+    GET_SCHEDULE_SIMPLE_PROFILE = "get_schedule_simple_profile"
+    GET_SCHEDULE_SIMPLE_WEEKDAY = "get_schedule_simple_weekday"
     GET_SCHEDULE_WEEKDAY = "get_schedule_weekday"
     GET_VARIABLE_VALUE = "get_variable_value"
     LIGHT_SET_ON_TIME = "light_set_on_time"

--- a/custom_components/homematicip_local/services.py
+++ b/custom_components/homematicip_local/services.py
@@ -605,6 +605,31 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async_register_platform_entity_service(
         hass=hass,
         service_domain=DOMAIN,
+        service_name=HmipLocalServices.GET_SCHEDULE_SIMPLE_PROFILE,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_PROFILE): cv.string,
+        },
+        func="async_get_schedule_simple_profile",
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    async_register_platform_entity_service(
+        hass=hass,
+        service_domain=DOMAIN,
+        service_name=HmipLocalServices.GET_SCHEDULE_SIMPLE_WEEKDAY,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required(ATTR_PROFILE): cv.string,
+            vol.Required(ATTR_WEEKDAY): cv.string,
+        },
+        func="async_get_schedule_simple_weekday",
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    async_register_platform_entity_service(
+        hass=hass,
+        service_domain=DOMAIN,
         service_name=HmipLocalServices.SET_SCHEDULE_PROFILE,
         entity_domain=CLIMATE_DOMAIN,
         schema={

--- a/custom_components/homematicip_local/services.yaml
+++ b/custom_components/homematicip_local/services.yaml
@@ -270,6 +270,57 @@ get_schedule_weekday:
             - "SATURDAY"
             - "SUNDAY"
 
+get_schedule_simple_profile:
+  target:
+    entity:
+      domain: climate
+      integration: homematicip_local
+  fields:
+    profile:
+      required: true
+      example: P1
+      selector:
+        select:
+          options:
+            - "P1"
+            - "P2"
+            - "P3"
+            - "P4"
+            - "P5"
+            - "P6"
+
+get_schedule_simple_weekday:
+  target:
+    entity:
+      domain: climate
+      integration: homematicip_local
+  fields:
+    profile:
+      required: true
+      example: P1
+      selector:
+        select:
+          options:
+            - "P1"
+            - "P2"
+            - "P3"
+            - "P4"
+            - "P5"
+            - "P6"
+    weekday:
+      required: true
+      example: MONDAY
+      selector:
+        select:
+          options:
+            - "MONDAY"
+            - "TUESDAY"
+            - "WEDNESDAY"
+            - "THURSDAY"
+            - "FRIDAY"
+            - "SATURDAY"
+            - "SUNDAY"
+
 get_variable_value:
   fields:
     entry_id:

--- a/custom_components/homematicip_local/strings.json
+++ b/custom_components/homematicip_local/strings.json
@@ -1369,17 +1369,27 @@
             "name": "Get paramset"
         }, 
         "get_schedule_profile": {
-            "description": "Call to get a schedule of a climate device", 
+            "description": "[DEPRECATED - will be removed April 2026] Use 'get_schedule_simple_profile' instead. Call to get a schedule of a climate device", 
             "fields": {
                 "profile": {
                     "description": "Select a profile", 
                     "name": "Profile"
                 }
             }, 
-            "name": "Get schedule profile"
+            "name": "[Deprecated] Get schedule profile"
         }, 
-        "get_schedule_weekday": {
-            "description": "Call to get a schedule of a climate device", 
+        "get_schedule_simple_profile": {
+            "description": "Call to get a schedule of a climate device in simplified format", 
+            "fields": {
+                "profile": {
+                    "description": "Select a profile", 
+                    "name": "Profile"
+                }
+            }, 
+            "name": "Get simple schedule profile"
+        }, 
+        "get_schedule_simple_weekday": {
+            "description": "Call to get a schedule of a climate device for a weekday in simplified format", 
             "fields": {
                 "profile": {
                     "description": "Select a profile", 
@@ -1390,7 +1400,21 @@
                     "name": "Weekday"
                 }
             }, 
-            "name": "Get schedule profile weekday"
+            "name": "Get simple schedule profile weekday"
+        }, 
+        "get_schedule_weekday": {
+            "description": "[DEPRECATED - will be removed April 2026] Use 'get_schedule_simple_weekday' instead. Call to get a schedule of a climate device", 
+            "fields": {
+                "profile": {
+                    "description": "Select a profile", 
+                    "name": "Profile"
+                }, 
+                "weekday": {
+                    "description": "Select a weekday", 
+                    "name": "Weekday"
+                }
+            }, 
+            "name": "[Deprecated] Get schedule profile weekday"
         }, 
         "get_variable_value": {
             "description": "Read a value of a variable", 

--- a/custom_components/homematicip_local/translations/de.json
+++ b/custom_components/homematicip_local/translations/de.json
@@ -1369,17 +1369,27 @@
             "name": "Parametersatz von einem Gerät oder Kanal lesen"
         }, 
         "get_schedule_profile": {
-            "description": "Lädt ein Zeitplan-Profil von einer Zeitplan-Entität", 
+            "description": "[VERALTET - wird im April 2026 entfernt] Verwende 'get_schedule_simple_profile' stattdessen. Lädt ein Zeitplan-Profil von einer Zeitplan-Entität", 
             "fields": {
                 "profile": {
                     "description": "Wählen Sie ein Profil zum Laden", 
                     "name": "Profil"
                 }
             }, 
-            "name": "Zeitplan-Profil abrufen"
+            "name": "[Veraltet] Zeitplan-Profil abrufen"
         }, 
-        "get_schedule_weekday": {
-            "description": "Lädt einen Wochentag eines Zeitplan-Profils", 
+        "get_schedule_simple_profile": {
+            "description": "Lädt ein Zeitplan-Profil von einer Zeitplan-Entität im vereinfachten Format", 
+            "fields": {
+                "profile": {
+                    "description": "Wählen Sie ein Profil zum Laden", 
+                    "name": "Profil"
+                }
+            }, 
+            "name": "Einfaches Zeitplan-Profil abrufen"
+        }, 
+        "get_schedule_simple_weekday": {
+            "description": "Lädt einen Wochentag eines Zeitplan-Profils im vereinfachten Format", 
             "fields": {
                 "profile": {
                     "description": "Wählen Sie ein Profil", 
@@ -1390,7 +1400,21 @@
                     "name": "Wochentag"
                 }
             }, 
-            "name": "Zeitplan-Profil Wochentag abrufen"
+            "name": "Einfaches Zeitplan-Profil Wochentag abrufen"
+        }, 
+        "get_schedule_weekday": {
+            "description": "[VERALTET - wird im April 2026 entfernt] Verwende 'get_schedule_simple_weekday' stattdessen. Lädt einen Wochentag eines Zeitplan-Profils", 
+            "fields": {
+                "profile": {
+                    "description": "Wählen Sie ein Profil", 
+                    "name": "Profil"
+                }, 
+                "weekday": {
+                    "description": "Wählen Sie einen Wochentag", 
+                    "name": "Wochentag"
+                }
+            }, 
+            "name": "[Veraltet] Zeitplan-Profil Wochentag abrufen"
         }, 
         "get_variable_value": {
             "description": "Wert einer Homematic Systemvariable lesen", 

--- a/custom_components/homematicip_local/translations/en.json
+++ b/custom_components/homematicip_local/translations/en.json
@@ -1369,29 +1369,53 @@
             "name": "Get paramset"
         }, 
         "get_schedule_profile": {
-            "description": "Call to get a schedule of a climate device", 
+            "description": "[DEPRECATED - will be removed April 2026] Use 'get_schedule_simple_profile' instead. Call to get a schedule of a climate device",
             "fields": {
                 "profile": {
-                    "description": "Select a profile", 
+                    "description": "Select a profile",
                     "name": "Profile"
                 }
-            }, 
-            "name": "Get schedule profile"
-        }, 
-        "get_schedule_weekday": {
-            "description": "Call to get a schedule of a climate device", 
+            },
+            "name": "[Deprecated] Get schedule profile"
+        },
+        "get_schedule_simple_profile": {
+            "description": "Call to get a schedule of a climate device in simplified format",
             "fields": {
                 "profile": {
-                    "description": "Select a profile", 
+                    "description": "Select a profile",
                     "name": "Profile"
-                }, 
+                }
+            },
+            "name": "Get simple schedule profile"
+        },
+        "get_schedule_simple_weekday": {
+            "description": "Call to get a schedule of a climate device for a weekday in simplified format",
+            "fields": {
+                "profile": {
+                    "description": "Select a profile",
+                    "name": "Profile"
+                },
                 "weekday": {
-                    "description": "Select a weekday", 
+                    "description": "Select a weekday",
                     "name": "Weekday"
                 }
-            }, 
-            "name": "Get schedule profile weekday"
-        }, 
+            },
+            "name": "Get simple schedule profile weekday"
+        },
+        "get_schedule_weekday": {
+            "description": "[DEPRECATED - will be removed April 2026] Use 'get_schedule_simple_weekday' instead. Call to get a schedule of a climate device",
+            "fields": {
+                "profile": {
+                    "description": "Select a profile",
+                    "name": "Profile"
+                },
+                "weekday": {
+                    "description": "Select a weekday",
+                    "name": "Weekday"
+                }
+            },
+            "name": "[Deprecated] Get schedule profile weekday"
+        },
         "get_variable_value": {
             "description": "Read a value of a variable", 
             "fields": {


### PR DESCRIPTION
Introduced new services `get_schedule_simple_profile` and `get_schedule_simple_weekday` to provide climate profile schedules in a simplified format. Updated documentation, service schemas, and translations. Deprecated the old `get_schedule_profile` and `get_schedule_weekday` services, which will be removed in April 2026.