### PR TITLE
feat: Multiple Devices in WRC6 Blueprint + optional direct connection collision checks [not backwards compatible]

### DIFF
--- a/blueprints/community/homematicip_local-actions-for-6-button-ho.yaml
+++ b/blueprints/community/homematicip_local-actions-for-6-button-ho.yaml
@@ -6,7 +6,9 @@ blueprint:
     to your configured minimum duration for long press. This can be configured in
     your CCU.
     Tested with HmIP-WRC6. Should work with other device too.
-    v2022-10-28
+    This variant of the original blueprint supports multiple devices, and alerting the user or skipping execution if there is a conflicting direct device connection in the CCU.
+    by @hosswald
+    v2026-02-08
   domain: automation
   source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-6-button.yaml
   input:

--- a/blueprints/community/homematicip_local-actions-for-6-button.yaml
+++ b/blueprints/community/homematicip_local-actions-for-6-button.yaml
@@ -1,0 +1,240 @@
+blueprint:
+  name: Actions for 6-Button Homematic(IP) device
+  description:
+    When a button is pressed, the defined actions will be executed. Please
+    keep in mind, that long-press actions might be executed multiple times, according
+    to your configured minimum duration for long press. This can be configured in
+    your CCU.
+    Tested with HmIP-WRC6. Should work with other device too.
+    v2022-10-28
+  domain: automation
+  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-6-button.yaml
+  input:
+    remote:
+      name: 6-Button Devices
+      description: Please select one or more 6-Button devices of your Homematic(IP) Local integration.
+      selector:
+        device:
+          integration: homematicip_local
+          multiple: true
+
+    notify_on_direct_links:
+      name: Warn if direct connections exist in CCU
+      description: >
+        A persistent notification will be sent if there is a direct connection in the CCU for the pressed button.
+      default: true
+      selector:
+        boolean: {}
+
+    skip_actions_when_direct_link:
+      name: Skip if direct connection exists in CCU
+      description: >
+        The configured action will be skipped if there is a direct connection in the CCU for the pressed button.
+      default: false
+      selector:
+        boolean: {}
+
+    action_left_top_short:
+      name: Action
+      description: Left-Top-Button, Short Press
+      default: []
+      selector:
+        action: {}
+    action_left_top_long:
+      name: Action
+      description: Left-Top-Button, Long Press
+      default: []
+      selector:
+        action: {}
+    action_right_top_short:
+      name: Action
+      description: Right-Top-Button, Short Press
+      default: []
+      selector:
+        action: {}
+    action_right_top_long:
+      name: Action
+      description: Right-Top-Button, Long Press
+      default: []
+      selector:
+        action: {}
+    action_left_middle_short:
+      name: Action
+      description: Left-Middle-Button, Short Press
+      default: []
+      selector:
+        action: {}
+    action_left_middle_long:
+      name: Action
+      description: Left-Middle-Button, Long Press
+      default: []
+      selector:
+        action: {}
+    action_right_middle_short:
+      name: Action
+      description: Right-Middle-Button, Short Press
+      default: []
+      selector:
+        action: {}
+    action_right_middle_long:
+      name: Action
+      description: Right-Middle-Button, Long Press
+      default: []
+      selector:
+        action: {}
+    action_left_bottom_short:
+      name: Action
+      description: Left-Bottom-Button, Short Press
+      default: []
+      selector:
+        action: {}
+    action_left_bottom_long:
+      name: Action
+      description: Left-Bottom-Button, Long Press
+      default: []
+      selector:
+        action: {}
+    action_right_bottom_short:
+      name: Action
+      description: Right-Bottom-Button, Short Press
+      default: []
+      selector:
+        action: {}
+    action_right_bottom_long:
+      name: Action
+      description: Right-Bottom-Button, Long Press
+      default: []
+      selector:
+        action: {}
+
+variables:
+  remotes: !input remote
+  notify_on_direct_links: !input notify_on_direct_links
+  skip_actions_when_direct_link: !input skip_actions_when_direct_link
+
+  action_left_top_short: !input action_left_top_short
+  action_left_top_long: !input action_left_top_long
+  action_right_top_short: !input action_right_top_short
+  action_right_top_long: !input action_right_top_long
+  action_left_middle_short: !input action_left_middle_short
+  action_left_middle_long: !input action_left_middle_long
+  action_right_middle_short: !input action_right_middle_short
+  action_right_middle_long: !input action_right_middle_long
+  action_left_bottom_short: !input action_left_bottom_short
+  action_left_bottom_long: !input action_left_bottom_long
+  action_right_bottom_short: !input action_right_bottom_short
+  action_right_bottom_long: !input action_right_bottom_long
+
+trigger:
+  - platform: event
+    event_type: homematic.keypress
+
+condition:
+  - condition: template
+    value_template: >-
+      {% set selected = remotes if remotes is list else [remotes] %}
+      {{ trigger.event.data.device_id in selected }}
+
+action:
+  - variables:
+      channel: "{{ trigger.event.data.subtype }}"
+      has_configured_action: >-
+        {% set t = trigger.event.data.type %}
+        {% set s = trigger.event.data.subtype %}
+        {% if t == 'press_short' and s == 1 %}{{ (action_left_top_short | default([])) | length > 0 }}
+        {% elif t == 'press_long' and s == 1 %}{{ (action_left_top_long | default([])) | length > 0 }}
+        {% elif t == 'press_short' and s == 2 %}{{ (action_right_top_short | default([])) | length > 0 }}
+        {% elif t == 'press_long' and s == 2 %}{{ (action_right_top_long | default([])) | length > 0 }}
+        {% elif t == 'press_short' and s == 3 %}{{ (action_left_middle_short | default([])) | length > 0 }}
+        {% elif t == 'press_long' and s == 3 %}{{ (action_left_middle_long | default([])) | length > 0 }}
+        {% elif t == 'press_short' and s == 4 %}{{ (action_right_middle_short | default([])) | length > 0 }}
+        {% elif t == 'press_long' and s == 4 %}{{ (action_right_middle_long | default([])) | length > 0 }}
+        {% elif t == 'press_short' and s == 5 %}{{ (action_left_bottom_short | default([])) | length > 0 }}
+        {% elif t == 'press_long' and s == 5 %}{{ (action_left_bottom_long | default([])) | length > 0 }}
+        {% elif t == 'press_short' and s == 6 %}{{ (action_right_bottom_short | default([])) | length > 0 }}
+        {% elif t == 'press_long' and s == 6 %}{{ (action_right_bottom_long | default([])) | length > 0 }}
+        {% else %}false{% endif %}
+
+  - service: homematicip_local.get_link_peers
+    data:
+      device_id: "{{ trigger.event.data.device_id }}"
+      channel: "{{ channel }}"
+    response_variable: link_peers
+
+  - variables:
+      direct_link_peer_count: >-
+        {% set lists = (link_peers.values() | list) if link_peers is mapping else [] %}
+        {{ lists | map('count') | sum }}
+      has_direct_link: "{{ (direct_link_peer_count | int(0)) > 0 }}"
+
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ notify_on_direct_links and has_direct_link and has_configured_action }}"
+        sequence:
+          - service: persistent_notification.create
+            data:
+              title: "Homematic CCU direct connection detected"
+              message: >-
+                Device {{ trigger.event.data.device_id }}, channel {{ channel }} has direct CCU links (peers).
+                A Home Assistant action is configured for this button, but the CCU may also handle it directly.
+
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ skip_actions_when_direct_link and has_direct_link and has_configured_action }}"
+        sequence:
+          - stop: "Skipped blueprint actions: CCU direct connection exists for this channel."
+
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_short' and trigger.event.data.subtype  == 1 }}"
+        sequence: !input "action_left_top_short"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_long' and trigger.event.data.subtype  == 1 }}"
+        sequence: !input "action_left_top_long"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_short' and trigger.event.data.subtype  == 2 }}"
+        sequence: !input "action_right_top_short"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_long' and trigger.event.data.subtype  == 2 }}"
+        sequence: !input "action_right_top_long"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_short' and trigger.event.data.subtype  == 3 }}"
+        sequence: !input "action_left_middle_short"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_long' and trigger.event.data.subtype  == 3 }}"
+        sequence: !input "action_left_middle_long"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_short' and trigger.event.data.subtype  == 4 }}"
+        sequence: !input "action_right_middle_short"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_long' and trigger.event.data.subtype  == 4 }}"
+        sequence: !input "action_right_middle_long"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_short' and trigger.event.data.subtype  == 5 }}"
+        sequence: !input "action_left_bottom_short"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_long' and trigger.event.data.subtype  == 5 }}"
+        sequence: !input "action_left_bottom_long"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_short' and trigger.event.data.subtype  == 6 }}"
+        sequence: !input "action_right_bottom_short"
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.type  == 'press_long' and trigger.event.data.subtype  == 6 }}"
+        sequence: !input "action_right_bottom_long"
+
+mode: parallel
+max: 10


### PR DESCRIPTION
Copied the WRC6 blueprint to community folder and made the following changes:

- multiple triggering devices can be selected
- options for skipping and/or warning if there is a conflicting direct connection

The change is not backwards compatible, i.e. existing automations will break when re-importing, due to the change from single value to list of values.