### PR TITLE
chore(repo): switch default branch from devel to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Homematic(IP) Local for OpenCCU custom_component
 
-If there is anything you want to see in Homematic(IP) Local for OpenCCU custom_component (features, bugfixes etc.), you can fork this repository, make your changes and then create a pull request (against the devel-branch). Just like with most of the other repositories here.
+If there is anything you want to see in Homematic(IP) Local for OpenCCU custom_component (features, bugfixes etc.), you can fork this repository, make your changes and then create a pull request (against the main-branch). Just like with most of the other repositories here.
 
 Please restrict your changes to the actual code within the custom_components/homematicip_local-directory. The repository-maintainers are keeping track of changes and will updated the changelog and setup.py.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -158,7 +158,7 @@ This includes:
 ## Pull Request Guidelines
 
 ### Target Branch
-- **Always target**: `devel` (NOT `master`)
+- **Always target**: `main`
 
 ### Commit Message Format
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 "on":
   push:
-    branches: [dev_1]
+    branches: [main]
   pull_request:
-    branches: [dev_1]
+    branches: [main]
   schedule:
     - cron: "17 4 * * 1"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,13 +3,11 @@ name: Pre-commit checks
 # yamllint disable-line rule:truthy
 on:
   pull_request:
-    branches-ignore:
-      - master
-      - devel
+    branches:
+      - main
   push:
     branches-ignore:
-      - master
-      - devel
+      - main
     tags-ignore:
       - "**"
 permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,7 @@ repos:
         exclude: (.vscode|.devcontainer)
       - id: no-commit-to-branch
         args:
-          - --branch=devel
-          - --branch=master
+          - --branch=main
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.38.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -752,8 +752,7 @@ prek run prettier --all-files
 
 ### Branch Structure
 
-- **Main Branch**: `master` (protected)
-- **Development Branch**: `devel` (protected)
+- **Default Branch**: `main` (protected)
 - **Feature Branches**: `feature/description`
 - **Bug Fix Branches**: `fix/description`
 
@@ -790,12 +789,12 @@ Added retry logic with exponential backoff for validation calls.
 
 ### Pull Request Process
 
-1. **Create feature branch** from `devel`
+1. **Create feature branch** from `main`
 2. **Make changes** with tests
 3. **Run prek hooks**: `prek run --all-files`
 4. **Commit changes** with descriptive messages
 5. **Push to remote**: `git push -u origin feature/branch-name`
-6. **Create Pull Request** to `devel` branch
+6. **Create Pull Request** to `main` branch
 7. **Wait for CI** to pass
 8. **Request review** from maintainers
 
@@ -961,7 +960,7 @@ These rules govern how the AI assistant communicates and works with the develope
 
 ❌ **Never** commit without type annotations
 ❌ **Never** skip prek hooks
-❌ **Never** commit to `master` or `devel` directly
+❌ **Never** commit to `main` directly
 ❌ **Never** use `Any` type without justification
 ❌ **Never** use bare `except:` clauses
 ❌ **Never** break backward compatibility without major version bump

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,18 +242,17 @@ open htmlcov/index.html
 
 ### Branch Structure
 
-- **`master`**: Stable release branch (protected)
-- **`devel`**: Development branch (protected)
+- **`main`**: Default branch (protected)
 - **Feature branches**: `feature/description` or `fix/description`
 
 ### Workflow
 
 1. **Fork the repository** (external contributors) or create a branch (maintainers)
 
-2. **Create a feature branch** from `devel`:
+2. **Create a feature branch** from `main`:
    ```bash
-   git checkout devel
-   git pull origin devel
+   git checkout main
+   git pull origin main
    git checkout -b feature/my-feature
    ```
 
@@ -282,7 +281,7 @@ open htmlcov/index.html
    git push -u origin feature/my-feature
    ```
 
-7. **Create a Pull Request** to the `devel` branch
+7. **Create a Pull Request** to the `main` branch
 
 ### Commit Message Format
 
@@ -321,7 +320,7 @@ connection validation during config flow.
 - **Title**: Clear, descriptive title
 - **Description**: Explain what and why (not how)
 - **Link issues**: Reference related issues with `Closes #123`
-- **Target branch**: Always target `devel`, not `master`
+- **Target branch**: Always target `main`
 - **Pass CI checks**: All automated checks must pass
 - **Code review**: Be responsive to feedback
 
@@ -330,8 +329,8 @@ connection validation during config flow.
 1. **Automated CI checks** run (tests, linting, type checking)
 2. **Code review** by maintainers
 3. **Discussion and iteration** if changes are needed
-4. **Merge to `devel`** once approved
-5. **Release to `master`** in next version
+4. **Merge to `main`** once approved
+5. **Tag a release** from `main` in next version
 
 ---
 

--- a/blueprints/automation/homematicip_local-actions-for-2-button.yaml
+++ b/blueprints/automation/homematicip_local-actions-for-2-button.yaml
@@ -10,7 +10,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-2-button.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local-actions-for-2-button.yaml
   input:
     remote:
       name: 2-Button Device

--- a/blueprints/automation/homematicip_local-actions-for-6-button.yaml
+++ b/blueprints/automation/homematicip_local-actions-for-6-button.yaml
@@ -10,7 +10,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-6-button.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local-actions-for-6-button.yaml
   input:
     remote:
       name: 6-Button Device

--- a/blueprints/automation/homematicip_local-actions-for-8-button.yaml
+++ b/blueprints/automation/homematicip_local-actions-for-8-button.yaml
@@ -10,7 +10,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-8-button.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local-actions-for-8-button.yaml
   input:
     remote:
       name: 8-Button Device

--- a/blueprints/automation/homematicip_local-actions-for-key_ring_remote_control.yaml
+++ b/blueprints/automation/homematicip_local-actions-for-key_ring_remote_control.yaml
@@ -10,7 +10,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-key_ring_remote_control.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local-actions-for-key_ring_remote_control.yaml
   input:
     remote:
       name: 4-Button Device (e.g. HmIP-KRCA)

--- a/blueprints/automation/homematicip_local_persistent_notification.yaml
+++ b/blueprints/automation/homematicip_local_persistent_notification.yaml
@@ -5,7 +5,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local_persistent_notification.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local_persistent_notification.yaml
 
 mode: restart
 max_exceeded: silent

--- a/blueprints/automation/homematicip_local_reactivate_device_by_model.yaml
+++ b/blueprints/automation/homematicip_local_reactivate_device_by_model.yaml
@@ -5,7 +5,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local_reactivate_device_by_model.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local_reactivate_device_by_model.yaml
   input:
     model:
       name: Model

--- a/blueprints/automation/homematicip_local_reactivate_device_full.yaml
+++ b/blueprints/automation/homematicip_local_reactivate_device_full.yaml
@@ -5,7 +5,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local_reactivate_device_full.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local_reactivate_device_full.yaml
   input:
     delay_seconds:
       name: Delay before reactivation (seconds)

--- a/blueprints/automation/homematicip_local_reactivate_single_device.yaml
+++ b/blueprints/automation/homematicip_local_reactivate_single_device.yaml
@@ -5,7 +5,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local_reactivate_single_device.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local_reactivate_single_device.yaml
   input:
     device_id:
       name: Homematic device

--- a/blueprints/automation/homematicip_local_show_device_error.yaml
+++ b/blueprints/automation/homematicip_local_show_device_error.yaml
@@ -6,7 +6,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local_show_device_error.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local_show_device_error.yaml
 
 mode: restart
 max_exceeded: silent

--- a/blueprints/community/homematicip_local-actions-for-12-button.yaml
+++ b/blueprints/community/homematicip_local-actions-for-12-button.yaml
@@ -10,7 +10,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/community/homematicip_local-actions-for-12-button.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/community/homematicip_local-actions-for-12-button.yaml
   input:
     remote:
       name: 12-Button Device

--- a/blueprints/community/homematicip_local-actions-for-4-button-fm.yaml
+++ b/blueprints/community/homematicip_local-actions-for-4-button-fm.yaml
@@ -10,7 +10,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/community/homematicip_local-actions-for-4-button-fm.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/community/homematicip_local-actions-for-4-button-fm.yaml
   input:
     remote:
       name: 4-Button Device (e.g. HM-PBI-4-FM)

--- a/blueprints/community/homematicip_local-actions-for-6-button-ho.yaml
+++ b/blueprints/community/homematicip_local-actions-for-6-button-ho.yaml
@@ -12,7 +12,7 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
-  source_url: https://github.com/sukramj/homematicip_local/blob/devel/blueprints/automation/homematicip_local-actions-for-6-button.yaml
+  source_url: https://github.com/sukramj/homematicip_local/blob/main/blueprints/automation/homematicip_local-actions-for-6-button.yaml
   input:
     remote:
       name: 6-Button Devices

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,6 +1,6 @@
 # Naming of devices and entities
 
-This document explains how Homematic(IP) Local for OpenCCU names devices and entities in Home Assistant. It is inspired by and largely aligned with the AIOhomematic naming documentation: https://github.com/SukramJ/aiohomematic/blob/devel/docs/naming.md. Where Homematic(IP) Local for OpenCCU behaves differently, this is highlighted.
+This document explains how Homematic(IP) Local for OpenCCU names devices and entities in Home Assistant. It is inspired by and largely aligned with the AIOhomematic naming documentation: https://github.com/SukramJ/aiohomematic/blob/main/docs/naming.md. Where Homematic(IP) Local for OpenCCU behaves differently, this is highlighted.
 
 ## Terminology
 - Device: A physical device registered on the CCU (or a hub-level pseudo device). In HA this is the Device entry in the device registry.


### PR DESCRIPTION
## Summary

Retire the `devel` branch in favour of a single `main` branch and point CI, tooling, and documentation at `main` (mirrors the same change in aiohomematic).

## Changes

- **Workflows**:
  - `codeql.yml` now triggers on `main` — it previously referenced a stale `dev_1` branch and therefore never ran on PRs/pushes.
  - `pre-commit.yml` now runs on PRs to `main` and on pushes to feature branches (was `branches-ignore: master/devel`).
- **Branch protection hook**: `.pre-commit-config.yaml` `no-commit-to-branch` now protects `main`.
- **Docs**: `CLAUDE.md`, `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`, `copilot-instructions.md` updated to target `main`.
- **Permalinks**: 12 blueprint `source_url`s + `docs/naming.md` rewritten from `blob/devel/*` to `blob/main/*` (the aiohomematic `devel` branch was also removed, so the cross-repo link in naming.md would have 404'd).

## Notes

- Historical `changelog.md` entries and Homematic `master`-channel terminology left untouched.
- `devel` branch deletion performed separately after merge.