### PR TITLE
chore(ci): harden CI supply chain and enrich dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,24 @@
 version: 2
 updates:
+  # Keep GitHub Actions (including SHA-pinned ones) up to date
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "SukramJ"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      # Group all GitHub Actions updates into a single PR
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'SukramJ'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6.0.2
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: "0.1"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,6 +34,6 @@ jobs:
           pip install -r requirements_test.txt
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
         with:
           extra_args: --all-files

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -83,7 +83,7 @@ jobs:
           echo "$BODY" > /tmp/release_body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           name: ${{ steps.version.outputs.version }}
           body_path: /tmp/release_body.md

--- a/.github/workflows/test-run.yaml
+++ b/.github/workflows/test-run.yaml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.14"]
     steps:
       - name: Set Timezone
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42
         with:
           timezoneLinux: "Europe/Berlin"
           timezoneMacos: "Europe/Berlin"


### PR DESCRIPTION
## Summary

Supply-chain hardening and dependabot enrichment, following the repository-settings review.

## Changes

- **Pin third-party GitHub Actions to full commit SHA** (no inline version comment, because this repo's prettier and yamllint `min-spaces-from-content: 2` rule disagree on inline-comment spacing):
  - `dessant/lock-threads` → `89ae32b` (v6.0.2)
  - `szenius/set-timezone` → `1f9716b` (v2.0)
  - `softprops/action-gh-release` → `718ea10` (v3)
  - `pre-commit/action` → `2c7b380` (v3.0.1)
  - Official HA/HACS actions (`home-assistant/actions/hassfest@master`, `hacs/action@main`) and first-party `actions/*` keep their refs (ecosystem convention).
- **Enrich dependabot `github-actions` config**: weekly Monday schedule, reviewer, labels, conventional-commit prefix, and grouping so SHA bumps land in a single PR. Dependabot keeps the pinned SHAs current.

No `pip` ecosystem was added: runtime deps are pinned in both `manifest.json` and `requirements_test.txt`, so auto-bumping only the latter would create drift.

## Applied separately (repo settings, not in this PR)

- Branch protection on `main` (strict checks: pre-commit, test, validate, validate-hacs, CodeQL; conversation resolution; no force-push/deletion)
- Secret scanning + push protection → enabled
- Default workflow token → read-only
- Auto-delete merged branches → enabled