### PR TITLE
docs: note agentic AI-assisted development

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Enhance your Home Assistant dashboard with custom cards designed for this integr
 | **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | **Sponsor** | [GitHub Sponsors](https://github.com/sponsors/SukramJ) |
 
+## Development
+
+Parts of Homematic(IP) Local for OpenCCU are developed with agentic AI assistance, primarily [Claude Code](https://www.anthropic.com/claude-code). Submitted issues are also triaged and analysed with agentic help. Every change is still reviewed by a human maintainer and must pass the project's tests before it lands — AI accelerates the work, it does not replace the review gate.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds a short **Development** note to the README stating the project is developed with agentic AI assistance (Claude Code), that submitted issues are also triaged/analysed with agentic help, and that human review + the project test suite remain the merge gate. Docs-only.