### PR TITLE
fix(control_unit): keep entities of not-yet-loaded devices during orphan cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Version [2.8.1](https://github.com/SukramJ/homematicip_local/compare/2.8.0...2.8.1)
+
+## What's Changed
+
+### Integration
+
+- Fix the startup orphan cleanup permanently deleting entities of devices that are only still loading (e.g. a paramset-cache rebuild on upgrade, when the central reports `RUNNING` before every device is built), which re-created them disabled and under a new `entity_id`. Device entries whose device is not yet loaded are now kept; genuine orphans (device present but data point gone, or device removed) stay sweepable
+
 # Version [2.8.0](https://github.com/SukramJ/homematicip_local/compare/2.7.2...2.8.0) (2026-07-05)
 
 ## What's Changed

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -34,6 +34,7 @@ from aiohomematic.const import (
     DEFAULT_SYSVAR_MARKERS,
     DEFAULT_UN_IGNORES,
     DEFAULT_USE_GROUP_CHANNEL_FOR_COVER_STATE,
+    IDENTIFIER_SEPARATOR,
     IP_ANY_V4,
     PORT_ANY,
     CentralState,
@@ -491,11 +492,16 @@ class ControlUnit(BaseControlUnit):
         backend device removal) remain in the entity registry indefinitely and cannot
         be removed via the UI. This sweep removes them on integration startup.
         Only runs when the central is fully started so that we don't delete entries
-        whose data points just haven't been loaded yet. As an additional safeguard it
-        refuses to run when it would remove more than ``ORPHAN_CLEANUP_MAX_DELETE_RATIO``
-        of the registry entries, which protects against a permanent mass deletion when
-        the device descriptions failed to load despite the central reporting RUNNING
-        (see aiohomematic#3215).
+        whose data points just haven't been loaded yet. Device-anchored entries are
+        additionally cross-checked against the devices the central currently exposes:
+        an entry whose backing device is not (yet) loaded is kept, because a device
+        that is merely still materialising (e.g. after a paramset-cache rebuild on
+        upgrade) is indistinguishable from a removed one by unique_id alone, and
+        deleting would re-create the entity disabled and under a fresh entity_id. As
+        an additional safeguard it refuses to run when it would remove more than
+        ``ORPHAN_CLEANUP_MAX_DELETE_RATIO`` of the registry entries, which protects
+        against a permanent mass deletion when the device descriptions failed to load
+        despite the central reporting RUNNING (see aiohomematic#3215).
         """
         if self._config.backend == BACKEND_LOOM:
             # The openccu-loom adapter exposes only a partial hub-coordinator
@@ -549,6 +555,7 @@ class ControlUnit(BaseControlUnit):
             )
 
         entity_registry = er.async_get(self._hass)
+        device_registry = dr.async_get(self._hass)
         platform_entries: list[er.RegistryEntry] = [
             entry
             for entry in er.async_entries_for_config_entry(entity_registry, self._entry_id)
@@ -556,23 +563,26 @@ class ControlUnit(BaseControlUnit):
         ]
         central_id = self._config.central_id
 
-        def _is_true_orphan(entry: er.RegistryEntry) -> bool:
-            """Return True only for entries whose data point is genuinely gone."""
-            if entry.unique_id in current_unique_ids:
-                return False
-            # The per-central backup button is integration-native (not an
-            # aiohomematic routing key) and is recreated on every setup, so it must
-            # never be swept.
-            if entry.unique_id.endswith("_create_backup"):
-                return False
-            # Central-id drift: the data point still exists but the registry entry
-            # is on a stale central-id anchor (a prior entry_id / serial). The
-            # setup-time realign migration owns this; deleting here would discard
-            # the user's customisations permanently, so never treat it as an orphan.
-            realigned = realign_hub_unique_id(entry.unique_id, central_id=central_id)
-            return realigned is None or realigned not in current_unique_ids
+        # Device addresses the central currently exposes. A device data point can be
+        # absent from current_unique_ids for two very different reasons: its device
+        # is gone (genuine orphan) or its device simply has not finished
+        # materialising yet (e.g. a slow start or a paramset-cache rebuild after an
+        # upgrade, where the central reports RUNNING before every device is built).
+        # The two are indistinguishable from unique_ids alone, so device entries are
+        # cross-checked against this set below.
+        known_device_addresses: set[str] = {device.address for device in self._central.device_coordinator.devices}
 
-        orphaned_entries: list[er.RegistryEntry] = [entry for entry in platform_entries if _is_true_orphan(entry)]
+        orphaned_entries: list[er.RegistryEntry] = [
+            entry
+            for entry in platform_entries
+            if _is_orphan_registry_entry(
+                entry,
+                current_unique_ids=current_unique_ids,
+                known_device_addresses=known_device_addresses,
+                device_registry=device_registry,
+                central_id=central_id,
+            )
+        ]
 
         # Refuse implausibly large sweeps: a near-total wipe almost always means the
         # central is RUNNING (clients connected) while the device descriptions failed
@@ -1503,3 +1513,56 @@ def _cleanup_instance_name(*, instance_name: str) -> str:
     for char in ("/", "\\"):
         instance_name = instance_name.replace(char, "")
     return instance_name
+
+
+def _entry_device_address(*, entry: er.RegistryEntry, device_registry: dr.DeviceRegistry) -> str | None:
+    """
+    Return the backing device address of a device-anchored registry entry, else None.
+
+    Returns None for hub / program / sysvar / install-mode / virtual-remote entries
+    (their HA device is the central pseudo-device, whose identifier carries no
+    ``IDENTIFIER_SEPARATOR``) and for entries whose HA device no longer exists
+    (``device_id`` unset or the device already removed) — a genuine removal, which
+    must stay subject to the normal orphan rules.
+    """
+    if entry.device_id is None or (device := device_registry.async_get(entry.device_id)) is None:
+        return None
+    for domain, identifier in device.identifiers:
+        if domain != DOMAIN:
+            continue
+        address, separator, _interface_id = identifier.partition(IDENTIFIER_SEPARATOR)
+        if separator:
+            return address
+    return None
+
+
+def _is_orphan_registry_entry(
+    entry: er.RegistryEntry,
+    *,
+    current_unique_ids: set[str],
+    known_device_addresses: set[str],
+    device_registry: dr.DeviceRegistry,
+    central_id: str,
+) -> bool:
+    """Return True only for entries whose data point is genuinely gone."""
+    if entry.unique_id in current_unique_ids:
+        return False
+    # The per-central backup button is integration-native (not an aiohomematic
+    # routing key) and is recreated on every setup, so it must never be swept.
+    if entry.unique_id.endswith("_create_backup"):
+        return False
+    # Central-id drift: the data point still exists but the registry entry is on a
+    # stale central-id anchor (a prior entry_id / serial). The setup-time realign
+    # migration owns this; deleting here would discard the user's customisations
+    # permanently, so never treat it as an orphan.
+    realigned = realign_hub_unique_id(entry.unique_id, central_id=central_id)
+    if realigned is not None and realigned in current_unique_ids:
+        return False
+    # Device-presence guard: when the entry is backed by a device the central does
+    # not currently expose, the missing data point most likely means the device is
+    # still materialising rather than gone. Skipping avoids permanently deleting
+    # (and re-creating, disabled, under a fresh entity_id) entities whenever a
+    # device loads slowly. A genuine removal drops the HA device too, so the address
+    # resolves to None there and the entry stays sweepable.
+    device_address = _entry_device_address(entry=entry, device_registry=device_registry)
+    return device_address is None or device_address in known_device_addresses

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.6.1",
-    "openccu-loom-client==2026.7.1",
+    "openccu-loom-client==2026.7.3",
     "aiohomematic-config==2026.5.0",
     "aiohomematic==2026.7.1"
   ],
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.8.0",
+  "version": "2.8.1",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ aiohomematic_config==2026.5.0
 isal==1.8.0
 mypy==2.1.0
 openccu-data>=2026.6.1
-openccu-loom-client==2026.7.1
+openccu-loom-client==2026.7.3
 prek==0.4.8
 pur==7.4.0
 pylint==4.0.6

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from aiohomematic.const import CentralState, DeviceTriggerEventType
+from aiohomematic.const import IDENTIFIER_SEPARATOR, CentralState, DeviceTriggerEventType
 from aiohomematic.exceptions import AuthFailure
 import custom_components.homematicip_local
 from custom_components.homematicip_local import (
@@ -30,7 +30,7 @@ from custom_components.homematicip_local.control_unit import ControlUnit
 from custom_components.homematicip_local.support import realign_hub_unique_id
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests import const
 
@@ -278,12 +278,14 @@ def _build_orphan_sweep_self(
     metrics_unique_ids: tuple[str, str, str] | None = None,
     connectivity_unique_ids: tuple[str, ...] = (),
     install_mode_unique_ids: tuple[tuple[str, str], ...] = (),
+    known_device_addresses: tuple[str, ...] = (),
     backend: str = BACKEND_CCU,
     central_id: str = "11a0001234",
 ) -> SimpleNamespace:
     """Build a minimal ControlUnit-shaped self for _async_cleanup_orphaned_entity_registry_entries."""
     central = MagicMock()
     central.state = state
+    central.device_coordinator.devices = tuple(SimpleNamespace(address=address) for address in known_device_addresses)
     central.query_facade.get_data_points.return_value = tuple(
         SimpleNamespace(unique_id=uid) for uid in data_point_unique_ids
     )
@@ -606,6 +608,138 @@ async def test_cleanup_orphan_entries_skipped_when_data_load_incomplete(
         assert entity_registry.async_get(entry.entity_id) is not None, (
             f"{entry.entity_id} was deleted despite an incomplete device load"
         )
+
+
+def _create_alive_entities(
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    count: int,
+) -> tuple[str, ...]:
+    """Create ``count`` entities whose data points are reported alive; return their unique_id stems."""
+    stems = tuple(f"alive_{index}" for index in range(count))
+    for stem in stems:
+        entity_registry.async_get_or_create(
+            domain="sensor",
+            platform=HMIP_DOMAIN,
+            unique_id=f"{HMIP_DOMAIN}_{stem}",
+            config_entry=mock_config_entry,
+        )
+    return stems
+
+
+async def test_cleanup_orphan_entries_keeps_entry_of_not_yet_loaded_device(
+    hass: HomeAssistant,
+    mock_config_entry_v2: MockConfigEntry,
+) -> None:
+    """
+    A device entry whose device is not (yet) loaded must be kept, not swept.
+
+    When the central reports RUNNING before every device is materialised (e.g. a
+    paramset-cache rebuild on upgrade), the device's data points are missing from
+    ``get_data_points()``. Deleting the (disabled) entry would re-create the entity
+    disabled and under a fresh entity_id, breaking dashboards/automations/history.
+    The device-presence guard keeps it because the backing device is still known to
+    HA but absent from the central's loaded devices.
+    """
+    mock_config_entry_v2.add_to_hass(hass)
+    entry_id = mock_config_entry_v2.entry_id
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    alive = _create_alive_entities(entity_registry, mock_config_entry_v2, count=3)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(HMIP_DOMAIN, f"ABC0000001{IDENTIFIER_SEPARATOR}CCU-Homematic")},
+    )
+    calculated_disabled = entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_calculated_abc0000001_1_dew_point",
+        config_entry=mock_config_entry_v2,
+        device_id=device.id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    # Device ABC0000001 is NOT among the central's loaded devices -> not-yet-loaded.
+    fake_self = _build_orphan_sweep_self(hass, entry_id, data_point_unique_ids=alive)
+    ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
+
+    assert entity_registry.async_get(calculated_disabled.entity_id) is not None
+
+
+async def test_cleanup_orphan_entries_removes_entry_when_device_loaded_but_data_point_gone(
+    hass: HomeAssistant,
+    mock_config_entry_v2: MockConfigEntry,
+) -> None:
+    """A device entry whose device IS loaded but whose data point is gone stays sweepable.
+
+    This is the genuine-orphan case (e.g. un_ignore / profile change removed the
+    data point while the device itself is present), which must still be cleaned up.
+    """
+    mock_config_entry_v2.add_to_hass(hass)
+    entry_id = mock_config_entry_v2.entry_id
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    alive = _create_alive_entities(entity_registry, mock_config_entry_v2, count=3)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(HMIP_DOMAIN, f"ABC0000001{IDENTIFIER_SEPARATOR}CCU-Homematic")},
+    )
+    orphan_disabled = entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_abc0000001_1_gone_parameter",
+        config_entry=mock_config_entry_v2,
+        device_id=device.id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    # Device ABC0000001 IS loaded, but its data point is not reported -> real orphan.
+    fake_self = _build_orphan_sweep_self(
+        hass, entry_id, data_point_unique_ids=alive, known_device_addresses=("ABC0000001",)
+    )
+    ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
+
+    assert entity_registry.async_get(orphan_disabled.entity_id) is None
+
+
+async def test_cleanup_orphan_entries_removes_hub_anchored_entry_regardless_of_devices(
+    hass: HomeAssistant,
+    mock_config_entry_v2: MockConfigEntry,
+) -> None:
+    """A hub-anchored orphan is still swept: the guard only shields real device entries.
+
+    Hub / program / sysvar entries hang off the central pseudo-device, whose
+    identifier carries no ``IDENTIFIER_SEPARATOR``, so the device-presence guard must
+    not shield them even when no devices are loaded.
+    """
+    mock_config_entry_v2.add_to_hass(hass)
+    entry_id = mock_config_entry_v2.entry_id
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    alive = _create_alive_entities(entity_registry, mock_config_entry_v2, count=3)
+
+    hub_device = device_registry.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(HMIP_DOMAIN, "CCU-Homematic")},
+    )
+    hub_orphan = entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_deleted_sysvar",
+        config_entry=mock_config_entry_v2,
+        device_id=hub_device.id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    fake_self = _build_orphan_sweep_self(hass, entry_id, data_point_unique_ids=alive)
+    ControlUnit._async_cleanup_orphaned_entity_registry_entries(fake_self)
+
+    assert entity_registry.async_get(hub_orphan.entity_id) is None
 
 
 class TestLoomUniqueIdMigration:


### PR DESCRIPTION
## Problem

Manually enabled, disabled-by-default device sensors (e.g. the calculated dew-point / vapor-concentration sensors on wall thermostats) could be permanently deleted and re-created after an upgrade or a slow start — coming back **disabled** and under a **new `entity_id`**, which breaks dashboards, automations and history.

## Cause

The startup orphan cleanup removes any entity-registry entry whose data point is missing from the freshly loaded central. A device that is merely still materialising — e.g. while the paramset cache is rebuilt after an upgrade, when the central already reports `RUNNING` before every device is built — is indistinguishable by `unique_id` alone from a genuinely removed one, so its (disabled) entries were swept and then re-created from scratch.

## Fix

Device-anchored entries are now cross-checked against the devices the central currently exposes, via the backing HA device's identifier (`{address}@{interface_id}` for real devices vs. `central.name` for the hub pseudo-device):

- **Backing HA device exists but is not among the loaded devices** → kept (re-materialises on the next start). ← the actual fix
- **Device loaded, data point gone** (e.g. `un_ignore` / profile change) → still swept.
- **Backing HA device removed entirely** (real device removal) → still swept.
- **Hub / program / sysvar entries** (pseudo-device without an `@` identifier) → unchanged.

The two helpers were extracted to module level (`_entry_device_address`, `_is_orphan_registry_entry`) to stay within the complexity limit.

### Trade-off

Disabled leftovers of a device that was *really* removed in the backend are only swept once HA has already dropped its device-registry device. While that device still exists they linger (invisible) — the deliberate price for never again mistaking "not yet loaded" for "removed".

## Tests

Three new tests in `tests/test_init.py` cover the guard in all directions (not-yet-loaded device kept / loaded-but-data-point-gone swept / hub orphan still swept). Full suite: **825 passed, 6 skipped**; `prek run` (ruff, mypy strict, pylint, …) green.
