### PR TITLE
fix(support): realign calculated hub unique_ids onto live central id (#3272)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Integration
 
+- Fix calculated data points on internal / heating-group channels (Taupunkt/dew point, Dampfkonzentration/vapor concentration, Enthalpie/enthalpy, Taupunkt-Spreizung/dew-point spread) being orphan-deleted and re-created disabled under a new, name-doubled `entity_id` after the central-id realign migration (#3272). Their unique_ids carry a `calculated_` marker between the central-id slot and the channel infix (`<central-id>_calculated_int000…`), which `realign_hub_unique_id` did not recognise, so — unlike every other hub/internal key — they were left on the stale anchor, no longer matched the live central id, and were swept away by the orphan cleanup (losing manual enablement and history). The realign now handles the `calculated_` variant; device-anchored calculated DPs (`calculated_<serial>_…`, no central-id slot) stay untouched
 - Relax the aiohomematic version gate in `async_setup_entry` from an exact-match check to a minimum-version check. Setup is now only blocked when the installed aiohomematic is **older** than the version this release was built against; a newer (patch) aiohomematic no longer aborts setup. This fixes spurious "requires aiohomematic version X, but found version Y / setup blocked" failures (#3275) that occurred when HA/pip resolved a newer aiohomematic than the manifest pin via transitive, upper-bound-less dependencies
 
 ### Dependencies

--- a/custom_components/homematicip_local/support.py
+++ b/custom_components/homematicip_local/support.py
@@ -86,6 +86,10 @@ _HUB_KEY_INFIXES: Final[tuple[str, ...]] = (
     *_VIRTUAL_REMOTE_INFIXES,
 )
 _EVENT_GROUP_PREFIX: Final = "event_group_"
+# Calculated data points on internal / hub channels insert this marker between the
+# central-id slot and the infix: ``<central-id>_calculated_<infix>...``. Device-anchored
+# calculated DPs are spelled ``calculated_<serial>_...`` (no central-id slot) instead.
+_CALCULATED_MARKER: Final = "calculated_"
 
 
 def realign_hub_unique_id(unique_id: str, *, central_id: str) -> str | None:
@@ -119,10 +123,20 @@ def realign_hub_unique_id(unique_id: str, *, central_id: str) -> str | None:
         rebuilt = f"{prefix}{_EVENT_GROUP_PREFIX}{event_type}_{central_id}_{rest}"
         return rebuilt if rebuilt != unique_id else None
     # Standard hub / virtual-remote keys: <central-id>_<infix>...
+    # Calculated DPs on internal / hub channels carry an extra ``calculated_`` marker
+    # between the central-id slot and the infix (<central-id>_calculated_<infix>...);
+    # device-anchored calculated DPs (``calculated_<serial>_...``) have no central-id
+    # slot and fall through untouched.
     _slot, sep, rest = key.partition("_")
-    if not sep or not rest.startswith(_HUB_KEY_INFIXES):
+    if not sep:
         return None
-    rebuilt = f"{prefix}{central_id}_{rest}"
+    marker = ""
+    if rest.startswith(_CALCULATED_MARKER):
+        marker = _CALCULATED_MARKER
+        rest = rest[len(_CALCULATED_MARKER) :]
+    if not rest.startswith(_HUB_KEY_INFIXES):
+        return None
+    rebuilt = f"{prefix}{central_id}_{marker}{rest}"
     return rebuilt if rebuilt != unique_id else None
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -858,6 +858,7 @@ class TestRealignedHubUniqueId:
             f"{_D}_11a0001234_sysvar_x",  # already on the live anchor
             f"{_D}_openccu_create_backup",  # synthetic native button — not a routing key
             f"{_D}_event_group_keypress_0008dd8997b338_1",  # device event group — no central slot
+            f"{_D}_calculated_0008dd8997b338_1_dew_point",  # device-anchored calculated DP — no central slot
             "other_integration_xyz",  # not ours
         ],
     )
@@ -876,6 +877,16 @@ class TestRealignedHubUniqueId:
             (f"{_D}_a1b2c3d4e5_int0001234_1_level", f"{_D}_11a0001234_int0001234_1_level"),
             (f"{_D}_a1b2c3d4e5_bidcos_rf_1_press_short", f"{_D}_11a0001234_bidcos_rf_1_press_short"),
             (f"{_D}_w78v4413eq_hmip_rcv_1_9_press_long", f"{_D}_11a0001234_hmip_rcv_1_9_press_long"),
+            # Calculated DPs on internal/hub channels: the central-id slot sits before
+            # the `calculated_` marker and must be realigned like any other hub key.
+            (
+                f"{_D}_a1b2c3d4e5_calculated_int0001234_1_dew_point",
+                f"{_D}_11a0001234_calculated_int0001234_1_dew_point",
+            ),
+            (
+                f"{_D}_w78v4413eq_calculated_int0001234_1_vapor_concentration",
+                f"{_D}_11a0001234_calculated_int0001234_1_vapor_concentration",
+            ),
             # Virtual-remote event groups keep their event_group_<type>_ prefix.
             (
                 f"{_D}_event_group_keypress_w78v4413eq_bidcos_rf_1",
@@ -1000,6 +1011,14 @@ async def test_async_migrate_aiohomematic_hub_unique_ids_realigns_stale_anchor(h
         unique_id=f"{HMIP_DOMAIN}_{stale}_bidcos_rf_9_press_long",
         config_entry=entry,
     )
+    # Calculated DP on an internal heating-group channel: <central-id>_calculated_int...
+    # (regression for #3272 — these fell through the realign and were orphan-deleted).
+    calculated = entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_{stale}_calculated_int0001234_1_dew_point",
+        config_entry=entry,
+    )
     event_group = entity_registry.async_get_or_create(
         domain="event",
         platform=HMIP_DOMAIN,
@@ -1019,6 +1038,10 @@ async def test_async_migrate_aiohomematic_hub_unique_ids_realigns_stale_anchor(h
     assert (
         entity_registry.async_get(vremote.entity_id).unique_id
         == f"{HMIP_DOMAIN}_{serial_suffix}_bidcos_rf_9_press_long"
+    )
+    assert (
+        entity_registry.async_get(calculated.entity_id).unique_id
+        == f"{HMIP_DOMAIN}_{serial_suffix}_calculated_int0001234_1_dew_point"
     )
     assert (
         entity_registry.async_get(event_group.entity_id).unique_id


### PR DESCRIPTION
## Problem

Fixes SukramJ/aiohomematic#3272.

After the 2.8.x central-id realign migration, **calculated** data points on internal / heating-group channels — Taupunkt (`dew_point`), Dampfkonzentration (`vapor_concentration`), Enthalpie (`enthalpy`), Taupunkt-Spreizung (`dew_point_spread`) — were orphan-deleted and re-created **disabled** under a new, name-doubled `entity_id` (e.g. `sensor.bad_eg_heizung_bad_eg_dampfkonzentration` instead of `sensor.heizung_bad_eg_dampfkonzentration`), losing manual enablement and history.

## Root cause

The realign migration (`_async_realign_hub_unique_ids` → `support.realign_hub_unique_id`) rewrites the central-id slot of every hub/internal `unique_id` from the stale anchor (`entry_id[-10:]`) onto the live central id (CCU serial). It splits `<central-id>_<rest>` and requires `rest` to start with a known hub infix (`sysvar_`, `program_`, `int000`, …).

Calculated DPs on those channels insert an extra `calculated_` marker between the slot and the infix:

```
homematicip_local_<central-id>_calculated_int0000001_1_dew_point
```

so `rest` = `calculated_int0000001_1_dew_point` matched no infix → the key was skipped, left on the stale anchor, no longer matched the live-central data point, and was swept away by the orphan cleanup — then re-created fresh (disabled + colliding entity_id).

Evidence from the reporter's update log: 235 realign lines, **0** for `calculated`, immediately followed by 44 `Removing orphan … calculated_…` entries.

## Fix

`realign_hub_unique_id` now recognises the optional `calculated_` marker between the central-id slot and the infix and preserves it while realigning the slot. Device-anchored calculated DPs (`calculated_<serial>_…`, which have **no** central-id slot) continue to fall through untouched.

## Tests

Bug reproduced first: without the `support.py` change, the 3 new assertions fail; with it, all pass.

- `TestRealignedHubUniqueId.test_rewrites`: `dew_point` + `vapor_concentration` calculated keys realign onto the live anchor.
- `TestRealignedHubUniqueId.test_left_untouched`: device-anchored `calculated_<serial>_…` stays `None`.
- `test_async_migrate_aiohomematic_hub_unique_ids_realigns_stale_anchor`: registry-level regression now also covers a `calculated_int…` heating-group key.

`pytest tests/test_init.py tests/test_support.py` → 79 passed. `prek run` on changed files → all green.

## Version

Stays **2.8.2**; changelog entry added under the existing 2.8.2 section. No config-entry migration (unique_id realign only).