### PR TITLE
fix(events): classify HmIP-DSD-PCB as doorbell event (#3276)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Version [2.8.3](https://github.com/SukramJ/homematicip_local/compare/2.8.2...2.8.3) (2026-07-08)
+
+## What's Changed
+
+### Integration
+
+- Expose the HmIP-DSD-PCB doorbell sensor's event with the `doorbell` event device class instead of the generic `button` (#3276). Its ring input channel produces an event group that previously fell back to the `button` default; it now matches the doorbell rule alongside the HmIP-DBB
+
 # Version [2.8.2](https://github.com/SukramJ/homematicip_local/compare/2.8.1...2.8.2) (2026-07-08)
 
 ## What's Changed

--- a/custom_components/homematicip_local/entity_helpers/descriptions/events.py
+++ b/custom_components/homematicip_local/entity_helpers/descriptions/events.py
@@ -10,7 +10,9 @@ from homeassistant.components.event import EventDeviceClass
 EVENT_RULES: list[EntityDescriptionRule] = [
     EntityDescriptionRule(
         category=DataPointCategory.EVENT_GROUP,
-        devices=("HmIP-DBB",),
+        # HmIP-DBB: wireless doorbell button. HmIP-DSD-PCB: doorbell sensor PCB whose
+        # input channel signals a ring — both are doorbells, not generic buttons.
+        devices=("HmIP-DBB", "HmIP-DSD-PCB"),
         description=event(
             key="event_doorbell",
             device_class=EventDeviceClass.DOORBELL,

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.8.2",
+  "version": "2.8.3",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/tests/test_entity_helper.py
+++ b/tests/test_entity_helper.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from aiohomematic.const import DataPointCategory
 from custom_components.homematicip_local.entity_helpers import REGISTRY
+from homeassistant.components.event import EventDeviceClass
 
 
 class TestEntityHelper:
@@ -40,6 +43,29 @@ class TestEntityHelper:
 
         assert description is not None
         assert description.key == "BLIND"
+
+    @pytest.mark.parametrize("device_model", ["HmIP-DBB", "HmIP-DSD-PCB"])
+    def test_registry_find_doorbell_event(self, device_model: str) -> None:
+        """Doorbell devices expose their event group with the doorbell device class."""
+        description = REGISTRY.find(
+            category=DataPointCategory.EVENT_GROUP,
+            device_model=device_model,
+        )
+
+        assert description is not None
+        assert description.key == "event_doorbell"
+        assert description.device_class == EventDeviceClass.DOORBELL
+
+    def test_registry_find_event_defaults_to_button(self) -> None:
+        """A non-doorbell keypress device keeps the default button device class."""
+        description = REGISTRY.find(
+            category=DataPointCategory.EVENT_GROUP,
+            device_model="HmIP-WRC2",
+        )
+
+        assert description is not None
+        assert description.key == "event_default"
+        assert description.device_class == EventDeviceClass.BUTTON
 
     def test_registry_find_sensor(self) -> None:
         """Test finding a sensor description."""


### PR DESCRIPTION
## Problem

Fixes SukramJ/aiohomematic#3276 (feature request).

The **HmIP-DSD-PCB** doorbell sensor is exposed in Home Assistant as an event with `device_class: button` instead of `doorbell`.

## Root cause

The device's ring input channel (`:1`, `MULTI_MODE_INPUT_TRANSMITTER` with `PRESS_SHORT`/`PRESS_LONG`) is surfaced as an `EVENT_GROUP` data point. The `EVENT_GROUP` default device class is `button` (`entity_helpers/defaults.py`), and the only rule overriding it to `doorbell` matched `devices=("HmIP-DBB",)` — so the DSD-PCB fell back to `button`.

## Fix

Add `HmIP-DSD-PCB` to the doorbell `EVENT_GROUP` rule in `entity_helpers/descriptions/events.py`, so its event is exposed with `EventDeviceClass.DOORBELL` alongside the HmIP-DBB.

## Tests

`tests/test_entity_helper.py`:
- `test_registry_find_doorbell_event` (parametrized over `HmIP-DBB`, `HmIP-DSD-PCB`): resolves to `event_doorbell` / `DOORBELL`. Fails without the fix for `HmIP-DSD-PCB`.
- `test_registry_find_event_defaults_to_button`: a non-doorbell keypress device still resolves to the `button` default.

`pytest tests/test_entity_helper.py` → 9 passed. `prek run` on changed files → green.

## Version

Bumps to **2.8.3** (manifest + changelog).