### PR TITLE
feat(light): expose color temperature for HmIP-LSC (#3277)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,13 @@
 ### Integration
 
 - Expose the HmIP-DSD-PCB doorbell sensor's event with the `doorbell` event device class instead of the generic `button` (#3276). Its ring input channel produces an event group that previously fell back to the `button` default; it now matches the doorbell rule alongside the HmIP-DBB
+- Expose color temperature for the HmIP-LSC (#3277). `supported_color_modes` now also honours the light's static color capabilities (`capabilities.hs_color`/`capabilities.color_temperature`), so a light that supports both color and color temperature — like the HmIP-LSC, which has no `DEVICE_OPERATION_MODE` and switches between the two at runtime — advertises `{hs, color_temp}` statically while `color_mode` keeps reporting the currently active mode via `has_*`. Lights with a single, mode-based color capability are unaffected
+
+### Dependencies
+
+#### Bump aiohomematic to [2026.7.3](https://github.com/SukramJ/aiohomematic/compare/2026.7.2...2026.7.3)
+
+- HmIP-LSC now exposes color temperature in addition to color (#3277): a dedicated `CustomDpIpRGBWColorTempLight` advertises both color modes statically and derives the active mode from the value the device reports
 
 # Version [2.8.2](https://github.com/SukramJ/homematicip_local/compare/2.8.1...2.8.2) (2026-07-08)
 

--- a/custom_components/homematicip_local/light.py
+++ b/custom_components/homematicip_local/light.py
@@ -200,13 +200,20 @@ class AioHomematicLight(AioHomematicGenericRestoreEntity[CustomDpDimmer], LightE
     @override
     def supported_color_modes(self) -> set[ColorMode] | None:
         """Flag supported color modes."""
+        data_point = self._data_point
+        capabilities = data_point.capabilities
+        # supported_color_modes must be static, so it also honours the light's
+        # static color capabilities. Lights whose active color mode is dynamic
+        # (e.g. HmIP-LSC, which switches between hs and color_temp at runtime)
+        # advertise both modes via capabilities while has_* reports the currently
+        # active one for color_mode below.
         supported_color_modes: set[ColorMode] = set()
-        if self._data_point.has_hs_color:
+        if data_point.has_hs_color or capabilities.hs_color:
             supported_color_modes.add(ColorMode.HS)
-        if self._data_point.has_color_temperature:
+        if data_point.has_color_temperature or capabilities.color_temperature:
             supported_color_modes.add(ColorMode.COLOR_TEMP)
 
-        if len(supported_color_modes) == 0 and self._data_point.capabilities.brightness:
+        if len(supported_color_modes) == 0 and capabilities.brightness:
             supported_color_modes.add(ColorMode.BRIGHTNESS)
         if len(supported_color_modes) == 0:
             supported_color_modes.add(ColorMode.ONOFF)

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -14,7 +14,7 @@
     "openccu-data==2026.6.1",
     "openccu-loom-client==2026.7.4",
     "aiohomematic-config==2026.5.0",
-    "aiohomematic==2026.7.2"
+    "aiohomematic==2026.7.3"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,8 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.47.0
-aiohomematic-test-support==2026.7.2
-aiohomematic==2026.7.2
+aiohomematic-test-support==2026.7.3
+aiohomematic==2026.7.3
 aiohomematic_config==2026.5.0
 isal==1.8.0
 mypy==2.1.0

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -57,6 +57,8 @@ def create_mock_light(
     supports_color_temperature: bool = False,
     supports_brightness: bool = True,
     supports_effects: bool = False,
+    capability_hs_color: bool = False,
+    capability_color_temperature: bool = False,
     is_restored: bool = False,
     restored_state: MockRestoredState | None = None,
     is_fixed_color_light: bool = False,
@@ -82,6 +84,8 @@ def create_mock_light(
     # Static capabilities
     mock_capabilities = MagicMock()
     mock_capabilities.brightness = supports_brightness
+    mock_capabilities.hs_color = capability_hs_color
+    mock_capabilities.color_temperature = capability_color_temperature
     mock_data_point.capabilities = mock_capabilities
     mock_data_point.turn_on = AsyncMock()
     mock_data_point.turn_off = AsyncMock()
@@ -390,6 +394,29 @@ class TestAioHomematicLightSupportedColorModes:
         """Test supported color modes with ONOFF only."""
         light = create_mock_light(supports_hs_color=False, supports_color_temperature=False, supports_brightness=False)
         assert ColorMode.ONOFF in light.supported_color_modes
+
+    def test_supported_color_modes_static_capabilities_advertise_both(self) -> None:
+        """Test that static capabilities advertise both modes even when only one is active (HmIP-LSC)."""
+        # Color temperature is the active mode (has_*), but the light statically
+        # supports both. supported_color_modes must stay {HS, COLOR_TEMP}.
+        light = create_mock_light(
+            supports_hs_color=False,
+            supports_color_temperature=True,
+            capability_hs_color=True,
+            capability_color_temperature=True,
+        )
+        assert light.supported_color_modes == {ColorMode.HS, ColorMode.COLOR_TEMP}
+        assert light.color_mode == ColorMode.COLOR_TEMP
+
+        # Switching the active mode to hs must keep the same static supported set.
+        light = create_mock_light(
+            supports_hs_color=True,
+            supports_color_temperature=False,
+            capability_hs_color=True,
+            capability_color_temperature=True,
+        )
+        assert light.supported_color_modes == {ColorMode.HS, ColorMode.COLOR_TEMP}
+        assert light.color_mode == ColorMode.HS
 
 
 class TestAioHomematicLightSupportedFeatures:


### PR DESCRIPTION
## Summary

Companion to SukramJ/aiohomematic#3278. Fixes #3277 — makes the HmIP-LSC expose color temperature in addition to color.

`supported_color_modes` now also honours the light's **static** color capabilities (`capabilities.hs_color`/`capabilities.color_temperature`). A light that supports both color and color temperature — like the HmIP-LSC, which has no `DEVICE_OPERATION_MODE` and switches between the two at runtime — advertises `{hs, color_temp}` statically, while `color_mode` keeps reporting the currently active mode via `has_*`. Lights with a single, mode-based color capability are unaffected (their static color capabilities are `False`).

## Changes

- `light.py`: `supported_color_modes` = union of dynamic `has_*` and static `capabilities.*`
- `manifest.json`: version `2.8.3`, pin `aiohomematic==2026.7.3`
- Tests: mock helper gains explicit static-capability params (default `False`) + new test asserting the static set stays `{hs, color_temp}` while `color_mode` follows the active mode
- `changelog.md` → `2.8.3`

## Test

- `tests/test_light.py` + `tests/test_support.py`: 93 passed
- ruff / mypy green