### PR TITLE
fix(light): don't mix hs and color_temp on turn_on for HmIP-LSC (#3277)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Expose the HmIP-DSD-PCB doorbell sensor's event with the `doorbell` event device class instead of the generic `button` (#3276). Its ring input channel produces an event group that previously fell back to the `button` default; it now matches the doorbell rule alongside the HmIP-DBB
 - Expose color temperature for the HmIP-LSC (#3277). `supported_color_modes` now also honours the light's static color capabilities (`capabilities.hs_color`/`capabilities.color_temperature`), so a light that supports both color and color temperature — like the HmIP-LSC, which has no `DEVICE_OPERATION_MODE` and switches between the two at runtime — advertises `{hs, color_temp}` statically while `color_mode` keeps reporting the currently active mode via `has_*`. Lights with a single, mode-based color capability are unaffected
+- Fix `light.turn_on` not switching the HmIP-LSC from color to color temperature (#3277). `async_turn_on` treated the two color modes as independent and, when only a color temperature was requested, still forwarded the *current* `hs_color` — so `HUE`/`SATURATION` and `COLOR_TEMPERATURE` were written together in one `putParamset` and the device kept the old color. The modes are now mutually exclusive: an explicit `color_temp_kelvin` or `hs_color` request is sent on its own, and the current value is only restored when no color is requested
 
 ### Dependencies
 

--- a/custom_components/homematicip_local/light.py
+++ b/custom_components/homematicip_local/light.py
@@ -307,12 +307,21 @@ class AioHomematicLight(AioHomematicGenericRestoreEntity[CustomDpDimmer], LightE
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         hm_kwargs = LightOnArgs()
-        # Use color_temp_kelvin from kwargs, if not applicable use current color_temp_kelvin.
-        if color_temp_kelvin := kwargs.get(ATTR_COLOR_TEMP_KELVIN, self.color_temp_kelvin):
-            hm_kwargs["color_temp_kelvin"] = color_temp_kelvin
-        # Use hs_color from kwargs, if not applicable use current hs_color.
-        if hs_color := kwargs.get(ATTR_HS_COLOR, self.hs_color):
-            hm_kwargs["hs_color"] = hs_color
+        # Color modes are mutually exclusive: Home Assistant sends at most one of
+        # hs_color / color_temp_kelvin per turn_on. An explicit request must NOT be
+        # paired with the *other* mode's current value — a light that supports both
+        # (e.g. HmIP-LSC) would otherwise receive HUE/SATURATION and COLOR_TEMPERATURE
+        # together in one putParamset and keep the old mode instead of switching
+        # (#3277). Only when no color is requested do we restore the current value(s).
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            hm_kwargs["color_temp_kelvin"] = kwargs[ATTR_COLOR_TEMP_KELVIN]
+        elif ATTR_HS_COLOR in kwargs:
+            hm_kwargs["hs_color"] = kwargs[ATTR_HS_COLOR]
+        else:
+            if color_temp_kelvin := self.color_temp_kelvin:
+                hm_kwargs["color_temp_kelvin"] = color_temp_kelvin
+            if hs_color := self.hs_color:
+                hm_kwargs["hs_color"] = hs_color
         # Use brightness from kwargs, with optional last_brightness fallback when light is off.
         brightness: int | None = kwargs.get(ATTR_BRIGHTNESS)
         if brightness is None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -489,7 +489,7 @@ class TestAioHomematicLightTurnOn:
 
     @pytest.mark.asyncio
     async def test_turn_on_all_kwargs(self) -> None:
-        """Test turn on with all kwargs."""
+        """Test turn on with all kwargs; color modes are mutually exclusive (color_temp wins)."""
         light = create_mock_light(color_temp_kelvin=None, hs_color=None, brightness=None)
         await light.async_turn_on(
             **{
@@ -504,7 +504,8 @@ class TestAioHomematicLightTurnOn:
         call_kwargs = light._data_point.turn_on.call_args[1]
         assert call_kwargs.get("brightness") == 200
         assert call_kwargs.get("color_temp_kelvin") == 4500
-        assert call_kwargs.get("hs_color") == (240.0, 100.0)
+        # hs_color is NOT forwarded alongside color_temp_kelvin (mutually exclusive, #3277).
+        assert "hs_color" not in call_kwargs
         assert call_kwargs.get("ramp_time") == 2
         assert call_kwargs.get("effect") == "Strobe"
 
@@ -516,6 +517,16 @@ class TestAioHomematicLightTurnOn:
         light._data_point.turn_on.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_turn_on_color_temp_while_in_hs_mode_excludes_hs(self) -> None:
+        """Requesting a color temperature while in HS mode must not also send hs_color (#3277)."""
+        # Device currently in HS mode: color_temp_kelvin is None, hs_color is set.
+        light = create_mock_light(color_temp_kelvin=None, hs_color=(19.0, 92.0))
+        await light.async_turn_on(**{ATTR_COLOR_TEMP_KELVIN: 3300})
+        call_kwargs = light._data_point.turn_on.call_args[1]
+        assert call_kwargs.get("color_temp_kelvin") == 3300
+        assert "hs_color" not in call_kwargs
+
+    @pytest.mark.asyncio
     async def test_turn_on_defaults_brightness_to_255(self) -> None:
         """Test turn on defaults brightness to 255 when None."""
         light = create_mock_light(is_valid=True, brightness=None)
@@ -525,6 +536,16 @@ class TestAioHomematicLightTurnOn:
         light._data_point.turn_on.assert_called_once()
         call_kwargs = light._data_point.turn_on.call_args[1]
         assert call_kwargs.get("brightness") == 255
+
+    @pytest.mark.asyncio
+    async def test_turn_on_hs_while_in_color_temp_mode_excludes_color_temp(self) -> None:
+        """Requesting an hs color while in color-temp mode must not also send color_temp_kelvin."""
+        # Device currently in color-temp mode: hs_color is None, color_temp_kelvin is set.
+        light = create_mock_light(color_temp_kelvin=3300, hs_color=None)
+        await light.async_turn_on(**{ATTR_HS_COLOR: (180.0, 50.0)})
+        call_kwargs = light._data_point.turn_on.call_args[1]
+        assert call_kwargs.get("hs_color") == (180.0, 50.0)
+        assert "color_temp_kelvin" not in call_kwargs
 
     @pytest.mark.asyncio
     async def test_turn_on_uses_current_brightness(self) -> None:
@@ -597,6 +618,22 @@ class TestAioHomematicLightTurnOn:
         light._data_point.turn_on.assert_called_once()
         call_kwargs = light._data_point.turn_on.call_args[1]
         assert call_kwargs.get("ramp_time") == 3
+
+    @pytest.mark.asyncio
+    async def test_turn_on_without_color_restores_active_mode(self) -> None:
+        """A plain turn_on (no color requested) restores the currently active mode's value."""
+        # color-temp mode: only color_temp_kelvin is restored
+        light = create_mock_light(color_temp_kelvin=3300, hs_color=None)
+        await light.async_turn_on(**{ATTR_BRIGHTNESS: 100})
+        call_kwargs = light._data_point.turn_on.call_args[1]
+        assert call_kwargs.get("color_temp_kelvin") == 3300
+        assert "hs_color" not in call_kwargs
+        # hs mode: only hs_color is restored
+        light = create_mock_light(color_temp_kelvin=None, hs_color=(19.0, 92.0))
+        await light.async_turn_on(**{ATTR_BRIGHTNESS: 100})
+        call_kwargs = light._data_point.turn_on.call_args[1]
+        assert call_kwargs.get("hs_color") == (19.0, 92.0)
+        assert "color_temp_kelvin" not in call_kwargs
 
 
 class TestAsyncSetupEntry:


### PR DESCRIPTION
## Summary

Follow-up to #1197. Fixes the HmIP-LSC (and any light supporting both color modes) not switching **from color to color temperature** via `light.turn_on`.

## Root cause (verified from the reporter's DEBUG log)

`async_turn_on` treated the two color modes as independent:
```python
if color_temp_kelvin := kwargs.get(ATTR_COLOR_TEMP_KELVIN, self.color_temp_kelvin): ...
if hs_color := kwargs.get(ATTR_HS_COLOR, self.hs_color): ...
```
When only `color_temp_kelvin` was requested, the `self.hs_color` fallback still added the **current** color, so aiohomematic wrote `HUE`+`SATURATION`+`COLOR_TEMPERATURE` together in one `putParamset`:
```
putParamset(003CE4099E2136:1, VALUES, {'HUE': 19, 'SATURATION': 0.92, 'COLOR_TEMPERATURE': 3016, 'LEVEL': 0.46})
```
The device then discarded the temperature (reported `COLOR_TEMPERATURE=''`, `COLOR_TEMPERATURE_STATUS=1`/UNKNOWN) and kept the color. This exactly matches the symptom: it only worked when the device was already in color-temp mode (then `self.hs_color` is `None`, so nothing extra was sent).

## Fix

Color modes are now mutually exclusive — HA sends at most one per `turn_on`:
- explicit `color_temp_kelvin` → sent on its own
- explicit `hs_color` → sent on its own
- no color requested → restore the current value(s) (unchanged behaviour)

## Safety / regression coverage

- The only pre-existing test that changed was `test_turn_on_all_kwargs`, which asserted the old buggy behaviour (both modes forwarded from a single call — something HA never does). It now asserts the exclusivity.
- The **no-color path is bit-identical** to before, so single-mode lights (Dimmer, ColorDimmer, ColorTempDimmer, FixedColor, RGBW) are unaffected.
- Added tests: color_temp-from-hs excludes hs, hs-from-color_temp excludes color_temp, plain turn_on restores the active mode.
- `tests/test_light.py`: 85 passed; ruff/mypy green.

aiohomematic `2026.7.3` is unchanged — this is an integration-only fix.