### PR TITLE
Bump aiohomematic to 2026.7.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version [2.8.3](https://github.com/SukramJ/homematicip_local/compare/2.8.2...2.8.3) (2026-07-08)
+# Version [2.8.3](https://github.com/SukramJ/homematicip_local/compare/2.8.2...2.8.3) (2026-07-09)
 
 ## What's Changed
 
@@ -10,8 +10,9 @@
 
 ### Dependencies
 
-#### Bump aiohomematic to [2026.7.3](https://github.com/SukramJ/aiohomematic/compare/2026.7.2...2026.7.3)
+#### Bump aiohomematic to [2026.7.4](https://github.com/SukramJ/aiohomematic/compare/2026.7.2...2026.7.4)
 
+- Fix valve-only `HmIP-HEATING` groups (built from `HmIP-eTRV` valves without a wall thermostat) freezing `current_temperature` / `current_humidity` at the last-(re)start value (#3279). Follow-up to #3255: these groups always expose `HUMIDITY` and `HEATING_COOLING` on the group channel, but only a group containing a wall thermostat (`HmIP-WTH`/`STHD`) ever receives events for them — in a valve-only group those readable data points never refresh, and since #3228 `VirtualDevices` get no `getValue` fallback, so they dragged the whole custom climate data point to `is_valid=False` (leaving the climate entity in `value_state=restored` with a frozen current temperature) even though `ACTUAL_TEMPERATURE` kept arriving via events. #3255 only excluded the actuator values `LEVEL` / `STATE`; the climate validity check now also ignores `HUMIDITY` / `HEATING_COOLING`, so a group's climate validity follows its aggregated `ACTUAL_TEMPERATURE` regardless of whether a wall thermostat is present
 - HmIP-LSC now exposes color temperature in addition to color (#3277): a dedicated `CustomDpIpRGBWColorTempLight` advertises both color modes statically and derives the active mode from the value the device reports
 
 # Version [2.8.2](https://github.com/SukramJ/homematicip_local/compare/2.8.1...2.8.2) (2026-07-08)

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -14,7 +14,7 @@
     "openccu-data==2026.6.1",
     "openccu-loom-client==2026.7.4",
     "aiohomematic-config==2026.5.0",
-    "aiohomematic==2026.7.3"
+    "aiohomematic==2026.7.4"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,11 +1,11 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.47.0
-aiohomematic-test-support==2026.7.3
-aiohomematic==2026.7.3
+aiohomematic-test-support==2026.7.4
+aiohomematic==2026.7.4
 aiohomematic_config==2026.5.0
 isal==1.8.0
-mypy==2.1.0
+mypy>=2.1.0
 openccu-data>=2026.6.1
 openccu-loom-client==2026.7.4
 prek==0.4.8


### PR DESCRIPTION
## What's Changed

Bumps `aiohomematic` (and `aiohomematic-test-support`) from `2026.7.3` to `2026.7.4` and documents the change in the 2.8.3 changelog.

### aiohomematic 2026.7.4

- Fix valve-only `HmIP-HEATING` groups (built from `HmIP-eTRV` valves without a wall thermostat) freezing `current_temperature` / `current_humidity` at the last-(re)start value ([#3279](https://github.com/SukramJ/aiohomematic/issues/3279), follow-up to #3255). These groups always expose `HUMIDITY` and `HEATING_COOLING` on the group channel, but only a group containing a wall thermostat (`HmIP-WTH`/`STHD`) ever receives events for them — in a valve-only group those readable data points never refresh, and since #3228 `VirtualDevices` get no `getValue` fallback, so they dragged the whole custom climate data point to `is_valid=False` (leaving the climate entity in `value_state=restored` with a frozen current temperature) even though `ACTUAL_TEMPERATURE` kept arriving via events. The climate validity check now also ignores `HUMIDITY` / `HEATING_COOLING`.

### Other

- `requirements_test.txt`: relax the `mypy` pin from `==2.1.0` to `>=2.1.0`.

_Note: the loom backend remains out of scope for this release; the bundled `openccu-loom-client` pin is unchanged in behaviour and intentionally not documented in the changelog._