### PR TITLE
Bump aiohomematic to 2026.7.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types_or: [python]
         files: ^(custom_components/homematicip_local|tests)/.+\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.15.21
     hooks:
       - id: ruff
         args:

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version [2.8.3](https://github.com/SukramJ/homematicip_local/compare/2.8.2...2.8.3) (2026-07-09)
+# Version [2.8.3](https://github.com/SukramJ/homematicip_local/compare/2.8.2...2.8.3) (2026-07-10)
 
 ## What's Changed
 
@@ -10,8 +10,10 @@
 
 ### Dependencies
 
-#### Bump aiohomematic to [2026.7.4](https://github.com/SukramJ/aiohomematic/compare/2026.7.2...2026.7.4)
+#### Bump aiohomematic to [2026.7.5](https://github.com/SukramJ/aiohomematic/compare/2026.7.2...2026.7.5)
 
+- Fix the climate entity for HmIP-WTH-B (and other thermostats) failing to load — staying permanently `unavailable` — when the device's SETPOINT paramset description is incomplete (missing `MAX`, e.g. after a failed `getParamsetDescription`) (#3281). `max_temp` returned `None`, so caching the week profile raised an uncaught `TypeError` out of Home Assistant's entity setup, while an identical device with a complete paramset description worked fine. `max_temp` now falls back to a fixed upper bound (`30.5`) when neither a `TEMPERATURE_MAXIMUM` value nor a SETPOINT `MAX` is available (mirroring the existing `min_temp` guard), and the week-profile conversion now degrades gracefully — the entity loads and only the schedule stays uncached
+- Internal aiohomematic simplification (−5,800 LOC) from a consumer-surface audit against this integration: removes the unused `hmcli` console script, the `HomematicAPI` facade, `SysvarStateChangedEvent`, the `tracing` / `logging_context` modules and the Kind/payload property-metadata subsystem, and flattens 37 zero-use interface protocols (120 → 83). Every removed symbol was verified to have zero usage in homematicip_local, so there is no user-facing effect
 - Fix valve-only `HmIP-HEATING` groups (built from `HmIP-eTRV` valves without a wall thermostat) freezing `current_temperature` / `current_humidity` at the last-(re)start value (#3279). Follow-up to #3255: these groups always expose `HUMIDITY` and `HEATING_COOLING` on the group channel, but only a group containing a wall thermostat (`HmIP-WTH`/`STHD`) ever receives events for them — in a valve-only group those readable data points never refresh, and since #3228 `VirtualDevices` get no `getValue` fallback, so they dragged the whole custom climate data point to `is_valid=False` (leaving the climate entity in `value_state=restored` with a frozen current temperature) even though `ACTUAL_TEMPERATURE` kept arriving via events. #3255 only excluded the actuator values `LEVEL` / `STATE`; the climate validity check now also ignores `HUMIDITY` / `HEATING_COOLING`, so a group's climate validity follows its aggregated `ACTUAL_TEMPERATURE` regardless of whether a wall thermostat is present
 - HmIP-LSC now exposes color temperature in addition to color (#3277): a dedicated `CustomDpIpRGBWColorTempLight` advertises both color modes statically and derives the active mode from the value the device reports
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -14,7 +14,7 @@
     "openccu-data==2026.6.1",
     "openccu-loom-client==2026.7.4",
     "aiohomematic-config==2026.5.0",
-    "aiohomematic==2026.7.4"
+    "aiohomematic==2026.7.5"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,6 +7,7 @@ aiohomematic_config==2026.5.0
 isal==1.8.0
 openccu-data>=2026.6.1
 openccu-loom-client==2026.7.5
+mypy==2.1.0
 prek==0.4.8
 pur==7.4.0
 pylint==4.0.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,13 +1,12 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.47.0
-aiohomematic-test-support==2026.7.4
-aiohomematic==2026.7.4
+aiohomematic-test-support==2026.7.5
+aiohomematic==2026.7.5
 aiohomematic_config==2026.5.0
 isal==1.8.0
-mypy>=2.1.0
 openccu-data>=2026.6.1
-openccu-loom-client==2026.7.4
+openccu-loom-client==2026.7.5
 prek==0.4.8
 pur==7.4.0
 pylint==4.0.6

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.2
 python-typing-update==v0.8.1
-ruff==0.15.20
+ruff==0.15.21
 yamllint==1.38.0


### PR DESCRIPTION
## What's Changed

Bumps `aiohomematic` (and `aiohomematic-test-support`) from `2026.7.4` to `2026.7.5`, refreshes the test/tooling requirements, and documents the change in the 2.8.3 changelog.

### aiohomematic 2026.7.5

- Fix the climate entity for HmIP-WTH-B (and other thermostats) failing to load — staying permanently `unavailable` — when the device's SETPOINT paramset description is incomplete (missing `MAX`, e.g. after a failed `getParamsetDescription`) ([#3281](https://github.com/SukramJ/aiohomematic/issues/3281)). `max_temp` returned `None`, so caching the week profile raised an uncaught `TypeError` out of Home Assistant's entity setup. `max_temp` now falls back to a fixed upper bound (`30.5`) when neither a `TEMPERATURE_MAXIMUM` value nor a SETPOINT `MAX` is available, and the week-profile conversion degrades gracefully (the entity loads; only the schedule stays uncached).
- Internal aiohomematic simplification (−5,800 LOC) from a consumer-surface audit against this integration: removes the unused `hmcli` console script, the `HomematicAPI` facade, `SysvarStateChangedEvent`, the `tracing` / `logging_context` modules and the Kind/payload property-metadata subsystem, and flattens 37 zero-use interface protocols (120 → 83). Every removed symbol was verified to have zero usage in `homematicip_local`, so there is no user-facing effect.

### Tooling / test requirements

- `ruff` `0.15.20` → `0.15.21` (`.pre-commit-config.yaml`, `requirements_test_pre_commit.txt`).
- `requirements_test.txt`: aiohomematic test support to `2026.7.5`, drop the redundant `mypy` pin, plus routine refreshes.

_Note: the loom backend remains out of scope for this release; the bundled `openccu-loom-client` bump is intentionally not documented in the changelog. The local `.run/Home Assistant.run.xml` IDE change is unrelated and left out of this PR._