### PR TITLE
chore(deps): bump openccu-loom-client to 2026.7.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,10 @@
 - Fix valve-only `HmIP-HEATING` groups (built from `HmIP-eTRV` valves without a wall thermostat) freezing `current_temperature` / `current_humidity` at the last-(re)start value (#3279). Follow-up to #3255: these groups always expose `HUMIDITY` and `HEATING_COOLING` on the group channel, but only a group containing a wall thermostat (`HmIP-WTH`/`STHD`) ever receives events for them — in a valve-only group those readable data points never refresh, and since #3228 `VirtualDevices` get no `getValue` fallback, so they dragged the whole custom climate data point to `is_valid=False` (leaving the climate entity in `value_state=restored` with a frozen current temperature) even though `ACTUAL_TEMPERATURE` kept arriving via events. #3255 only excluded the actuator values `LEVEL` / `STATE`; the climate validity check now also ignores `HUMIDITY` / `HEATING_COOLING`, so a group's climate validity follows its aggregated `ACTUAL_TEMPERATURE` regardless of whether a wall thermostat is present
 - HmIP-LSC now exposes color temperature in addition to color (#3277): a dedicated `CustomDpIpRGBWColorTempLight` advertises both color modes statically and derives the active mode from the value the device reports
 
+#### Bump openccu-loom-client to `2026.7.6` (pins `openccu-loom-types==0.1.53`)
+
+- Groundwork bump for the still-disabled openccu-loom backend; it has no runtime effect while the backend master switch (`LOOM_BACKEND_SELECTABLE` in `const.py`) stays off. Advances the bundled loom client to `2026.7.6` and its transitively pinned `openccu-loom-types` from `0.1.50` to `0.1.53`
+
 # Version [2.8.2](https://github.com/SukramJ/homematicip_local/compare/2.8.1...2.8.2) (2026-07-08)
 
 ## What's Changed

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.6.1",
-    "openccu-loom-client==2026.7.4",
+    "openccu-loom-client==2026.7.6",
     "aiohomematic-config==2026.5.0",
     "aiohomematic==2026.7.6"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,10 +6,10 @@ aiohomematic==2026.7.6
 aiohomematic_config==2026.5.0
 isal==1.8.0
 openccu-data>=2026.6.1
-openccu-loom-client==2026.7.5
+openccu-loom-client==2026.7.6
 mypy==2.1.0
-prek==0.4.8
+prek==0.4.9
 pur==7.4.0
 pylint==4.0.6
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.34
+pytest-homeassistant-custom-component-framework==1.0.35


### PR DESCRIPTION
## What's Changed

Bumps the bundled **openccu-loom-client** from `2026.7.4` to `2026.7.6` in `manifest.json` (advances the transitively pinned `openccu-loom-types` from `0.1.50` to `0.1.53`).

The **openccu-loom backend remains disabled** (`LOOM_BACKEND_SELECTABLE = False`), so this is groundwork-only with **no runtime / user-facing effect**.

The `aiohomematic==2026.7.6` pin stays the **last** entry in the `requirements` list, so it still overrides any newer aiohomematic pulled transitively via the loom client's open `>=` range.

### Test tooling (test-only, no runtime impact)

- `prek` `0.4.8` → `0.4.9`
- `pytest-homeassistant-custom-component-framework` `1.0.34` → `1.0.35`

### Docs

- `changelog.md`: documented the loom-client bump in the 2.8.3 Dependencies section.