### PR TITLE
chore(deps): bump openccu-loom-client to 2026.7.7 (2.8.4)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-12)
+
+## What's Changed
+
+### Dependencies
+
+#### Bump openccu-loom-client to `2026.7.7` (pins `openccu-loom-types==0.1.54`)
+
+- Groundwork bump for the still-disabled openccu-loom backend; it has no runtime effect while the backend master switch (`LOOM_BACKEND_SELECTABLE` in `const.py`) stays off. Advances the bundled loom client from `2026.7.6` to `2026.7.7` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.1.54`
+
 # Version [2.8.3](https://github.com/SukramJ/homematicip_local/compare/2.8.2...2.8.3) (2026-07-10)
 
 ## What's Changed

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.6.1",
-    "openccu-loom-client==2026.7.6",
+    "openccu-loom-client==2026.7.7",
     "aiohomematic-config==2026.5.0",
     "aiohomematic==2026.7.6"
   ],
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.8.3",
+  "version": "2.8.4",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,8 +6,8 @@ aiohomematic==2026.7.6
 aiohomematic_config==2026.5.0
 isal==1.8.0
 openccu-data>=2026.6.1
-openccu-loom-client==2026.7.6
-mypy==2.1.0
+openccu-loom-client==2026.7.7
+mypy<=2.1.0
 prek==0.4.9
 pur==7.4.0
 pylint==4.0.6


### PR DESCRIPTION
## What's Changed

Prepares release **2.8.4**.

### Dependencies

- Bumps the bundled **openccu-loom-client** `2026.7.6` → `2026.7.7` in `manifest.json` (advances the transitively pinned `openccu-loom-types` `0.1.53` → `0.1.54`).
- The **openccu-loom backend remains disabled** (`LOOM_BACKEND_SELECTABLE = False`), so this is groundwork-only with **no runtime / user-facing effect**.
- The `aiohomematic==2026.7.6` pin stays the **last** entry in the `requirements` list, so it still overrides any newer aiohomematic pulled transitively via the loom client's open `>=` range.

### Test tooling

- Cap **mypy** `==2.1.0` → `<=2.1.0` in `requirements_test.txt`. This keeps type checking on the mypy version Home Assistant core is validated against — a newer mypy (e.g. `2.20`) produces spurious type errors against HA's typed code and stubs. Note: mypy is **not** a transitive dependency of `homeassistant` / `pytest-homeassistant-custom-component-framework`, so it must stay explicitly listed here (removing it breaks the CI mypy hook).

### Version / Docs

- Bumps the integration version to `2.8.4` (`manifest.json`).
- Adds the `2.8.4` changelog entry documenting the loom-client bump.