### PR TITLE
feat(loom): alarm control panel platform (openccu-loom backend only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types_or: [python]
         files: ^(custom_components/homematicip_local|tests)/.+\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.15.21
+    rev: v0.15.22
     hooks:
       - id: ruff
         args:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,37 @@
+# Version 2.8.5 (unreleased)
+
+## What's Changed
+
+### Features
+
+- **Alarm control panel (openccu-loom backend only).** The openccu-loom daemon
+  (≥ 0.42.0) ships a native, local-first alarm engine and models every alarm
+  area — plus, with two or more areas, an aggregate master panel — as a
+  first-class panel entity. The new `alarm_control_panel` platform spawns one
+  HA panel per loom panel: state tokens come daemon-computed and map 1:1 onto
+  `AlarmControlPanelState`; the configured protection modes map onto the arm
+  features (`perimeter` → home, `full` → away, `night`, `vacation`, `custom` →
+  custom bypass); live detail (mode, countdown, per-mode readiness, last
+  incident, walk test) lands in the extra state attributes; panels removed on
+  the daemon (area deleted) remove their entity. Dispatch runs on the loom
+  twin alone (`LOOM_DP_ALARM_CONTROL_PANEL`, a loom-only tuple that degrades
+  to empty on a CCU-only install — aiohomematic has no alarm engine, so the
+  direct-CCU path is untouched).
+
+### Dependencies
+
+#### Bump aiohomematic to `2026.7.7`
+
+- Adds the `ALARM_CONTROL_PANEL` category/type vocabulary the platform list
+  derives from (pure vocabulary, no behaviour change on the CCU path).
+
+#### Bump openccu-loom-client to `2026.7.12` (pins `openccu-loom-types==0.1.56`)
+
+- Full client-side alarm surface: `/alarm` REST facade, nine `alarm.*`
+  WebSocket events, store panel section, the categorised
+  `LoomDpAlarmControlPanel` twin and the refresh/removal bridging this
+  platform consumes.
+
 # Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-15)
 
 ## What's Changed

--- a/custom_components/homematicip_local/alarm_control_panel.py
+++ b/custom_components/homematicip_local/alarm_control_panel.py
@@ -1,0 +1,179 @@
+"""Alarm control panel platform for Homematic(IP) Local for OpenCCU.
+
+This platform exists only on the openccu-loom backend: the daemon
+(≥ 0.42.0) ships a native, local-first alarm engine and models each
+alarm area (plus — with two or more areas — an aggregate master panel)
+as a first-class panel entity. aiohomematic has no alarm engine, so
+there is no aiohomematic class to pair with — dispatch runs on the
+loom twin alone (``LOOM_DP_ALARM_CONTROL_PANEL`` degrades to the empty
+tuple on a CCU-only install and the platform spawns nothing).
+
+State tokens are daemon-computed (``alarmpanel.StateToken``) and match
+Home Assistant's ``AlarmControlPanelState`` values 1:1; commands map
+onto the daemon's protection modes exactly like its own MQTT command
+plane (``ARM_HOME`` → ``perimeter``, ``ARM_AWAY`` → ``full``, …). The
+master panel fans arm/disarm out to the real areas client-side,
+mirroring the daemon's MQTT ``MasterArm`` semantics.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast, override
+
+from aiohomematic.const import DataPointCategory, DataPointType
+from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity
+from homeassistant.components.alarm_control_panel.const import AlarmControlPanelEntityFeature, AlarmControlPanelState
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HomematicConfigEntry
+from .backend_types import LOOM_DP_ALARM_CONTROL_PANEL
+from .control_unit import ControlUnit, signal_new_data_point
+from .generic_entity import AioHomematicGenericHubEntity
+from .support import handle_homematic_errors
+
+if TYPE_CHECKING:
+    # Typing-only: the platform never instantiates without the loom backend
+    # (the dispatch tuple is empty on a CCU-only install), so the runtime
+    # import stays optional in backend_types.
+    from openccu_loom_client.compat.aiohomematic.model.alarm_panel import LoomDpAlarmControlPanel
+
+    from aiohomematic.interfaces.model import GenericHubDataPointProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Daemon protection mode → HA arm feature. The vocabulary is wire-stable
+# (docs/alarm-concept.md §13.3 in the openccu-loom repo).
+_FEATURE_BY_MODE: dict[str, AlarmControlPanelEntityFeature] = {
+    "perimeter": AlarmControlPanelEntityFeature.ARM_HOME,
+    "full": AlarmControlPanelEntityFeature.ARM_AWAY,
+    "night": AlarmControlPanelEntityFeature.ARM_NIGHT,
+    "vacation": AlarmControlPanelEntityFeature.ARM_VACATION,
+    "custom": AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HomematicConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Homematic(IP) Local for OpenCCU alarm control panel platform."""
+    control_unit: ControlUnit = entry.runtime_data
+
+    @callback
+    def async_add_alarm_control_panel(data_points: tuple[Any, ...]) -> None:
+        """Add alarm control panels from Homematic(IP) Local for OpenCCU."""
+        _LOGGER.debug("ASYNC_ADD_ALARM_CONTROL_PANEL: Adding %i data points", len(data_points))
+
+        if entities := [
+            AioHomematicAlarmControlPanel(
+                control_unit=control_unit,
+                data_point=data_point,
+            )
+            for data_point in data_points
+            # Loom-only surface: the tuple is empty on a CCU-only install,
+            # so a stray announce can never spawn a panel there.
+            if isinstance(data_point, LOOM_DP_ALARM_CONTROL_PANEL)
+        ]:
+            async_add_entities(entities)
+
+    entry.async_on_unload(
+        func=async_dispatcher_connect(
+            hass=hass,
+            signal=signal_new_data_point(entry_id=entry.entry_id, platform=DataPointCategory.ALARM_CONTROL_PANEL),
+            target=async_add_alarm_control_panel,
+        )
+    )
+
+    async_add_alarm_control_panel(
+        data_points=control_unit.get_new_data_points(data_point_type=DataPointType.ALARM_CONTROL_PANEL)
+    )
+
+
+class AioHomematicAlarmControlPanel(AioHomematicGenericHubEntity, AlarmControlPanelEntity):
+    """Representation of the HomematicIP alarm control panel entity (openccu-loom)."""
+
+    # The daemon enforces its per-area code policy server-side either way
+    # (an arm/disarm without a required code answers 403, surfaced as a
+    # toast); the flag only drives HA's code-prompt UX and follows the
+    # panel twin once the daemon exposes the policy on the entity.
+    _attr_code_arm_required = False
+
+    def __init__(
+        self,
+        control_unit: ControlUnit,
+        data_point: LoomDpAlarmControlPanel,
+    ) -> None:
+        """Initialize the alarm control panel entity."""
+        super().__init__(
+            control_unit=control_unit,
+            # The loom twin satisfies the hub protocol structurally (its
+            # protocol tail is pinned client-side); only the enum homes
+            # differ nominally, hence the cast.
+            data_point=cast("GenericHubDataPointProtocol", data_point),
+        )
+        features = AlarmControlPanelEntityFeature(0)
+        for mode in data_point.supported_modes:
+            features |= _FEATURE_BY_MODE.get(mode, AlarmControlPanelEntityFeature(0))
+        self._attr_supported_features = features
+        self._attr_code_arm_required = data_point.code_arm_required
+
+    @property
+    def _panel(self) -> LoomDpAlarmControlPanel:
+        """Return the data point as its concrete loom type."""
+        return cast("LoomDpAlarmControlPanel", self._data_point)
+
+    @property
+    @override
+    def alarm_state(self) -> AlarmControlPanelState | None:
+        """Return the daemon-computed panel state (tokens match 1:1)."""
+        try:
+            return AlarmControlPanelState(self._panel.state)
+        except ValueError:
+            _LOGGER.debug("Unknown alarm panel state token: %s", self._panel.state)
+            return None
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the panel's live detail (mode, countdown, readiness, incident)."""
+        return dict(self._panel.attributes)
+
+    @handle_homematic_errors
+    @override
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Arm in full mode (HA: away)."""
+        await self._panel.arm(mode="full", code=code)
+
+    @handle_homematic_errors
+    @override
+    async def async_alarm_arm_custom_bypass(self, code: str | None = None) -> None:
+        """Arm in the user-defined custom mode."""
+        await self._panel.arm(mode="custom", code=code)
+
+    @handle_homematic_errors
+    @override
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Arm in perimeter mode (HA: home)."""
+        await self._panel.arm(mode="perimeter", code=code)
+
+    @handle_homematic_errors
+    @override
+    async def async_alarm_arm_night(self, code: str | None = None) -> None:
+        """Arm in night mode."""
+        await self._panel.arm(mode="night", code=code)
+
+    @handle_homematic_errors
+    @override
+    async def async_alarm_arm_vacation(self, code: str | None = None) -> None:
+        """Arm in vacation mode."""
+        await self._panel.arm(mode="vacation", code=code)
+
+    @handle_homematic_errors
+    @override
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Disarm the panel's area (master: every area, best-effort)."""
+        await self._panel.disarm(code=code)

--- a/custom_components/homematicip_local/backend_types.py
+++ b/custom_components/homematicip_local/backend_types.py
@@ -18,7 +18,7 @@ aiohomematic class alone, so a CCU-only install is unaffected.
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, Any, cast
 
 from aiohomematic.model.custom import (
     CustomDpBlind,
@@ -35,21 +35,27 @@ from aiohomematic.model.custom import (
 from aiohomematic.model.generic import DpAction, DpButton, DpSwitch
 from aiohomematic.model.hub import ProgramDpSwitch, SysvarDpSwitch
 
+if TYPE_CHECKING:
+    from openccu_loom_client.compat.aiohomematic.model.alarm_panel import LoomDpAlarmControlPanel
+
 _g: object | None
 _c: object | None
 _h: object | None
+_a: object | None
 try:
     from openccu_loom_client.compat.aiohomematic.model import (
+        alarm_panel as _loom_alarm_panel,
         custom as _loom_custom,
         generic as _loom_generic,
         hub as _loom_hub,
     )
 except ImportError:  # pragma: no cover - CCU-only install
-    _g = _c = _h = None
+    _g = _c = _h = _a = None
 else:
     _g = _loom_generic
     _c = _loom_custom
     _h = _loom_hub
+    _a = _loom_alarm_panel
 
 
 def _pair[T](aio_cls: type[T], loom_attr: str, loom_module: object | None) -> tuple[type[T], ...]:
@@ -67,6 +73,23 @@ def _pair[T](aio_cls: type[T], loom_attr: str, loom_module: object | None) -> tu
     return (aio_cls,)
 
 
+def _loom_only(loom_attr: str, loom_module: object | None) -> tuple[type[Any], ...]:
+    """Return ``(loom_cls,)`` for a loom-native surface with no aiohomematic class.
+
+    Used for surfaces that exist only on the openccu-loom backend (the alarm
+    control panel: the CCU has no alarm engine, so aiohomematic ships no class
+    to pair with). Degrades to the *empty* tuple on a CCU-only install —
+    ``isinstance(x, ())`` is always ``False``, so the platform simply spawns
+    nothing. Callers annotate the constant with the concrete loom type so
+    ``isinstance`` narrows.
+    """
+    if loom_module is not None:
+        loom_cls = getattr(loom_module, loom_attr, None)
+        if loom_cls is not None:
+            return (cast("type[Any]", loom_cls),)
+    return ()
+
+
 # ---- generic ----
 DP_SWITCH = _pair(DpSwitch, "DpSwitch", _g)
 DP_ACTION = _pair(DpAction, "DpAction", _g)
@@ -76,6 +99,9 @@ DP_ACTION_OR_BUTTON: tuple[type[DpAction | DpButton], ...] = (*DP_ACTION, *DP_BU
 # ---- hub ----
 SYSVAR_DP_SWITCH = _pair(SysvarDpSwitch, "SysvarDpSwitch", _h)
 PROGRAM_DP_SWITCH = _pair(ProgramDpSwitch, "ProgramDpSwitch", _h)
+
+# ---- loom-only (no aiohomematic class) ----
+LOOM_DP_ALARM_CONTROL_PANEL: tuple[type[LoomDpAlarmControlPanel], ...] = _loom_only("LoomDpAlarmControlPanel", _a)
 
 # ---- custom ----
 CUSTOM_DP_SWITCH = _pair(CustomDpSwitch, "CustomDpSwitch", _c)

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,9 +12,9 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.6.1",
-    "openccu-loom-client==2026.7.10",
+    "openccu-loom-client==2026.7.12",
     "aiohomematic-config==2026.5.0",
-    "aiohomematic==2026.7.6"
+    "aiohomematic==2026.7.7"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,11 +2,11 @@
 
 async_upnp_client==0.47.0
 aiohomematic-test-support==2026.7.6
-aiohomematic==2026.7.6
+aiohomematic==2026.7.7
 aiohomematic_config==2026.5.0
 isal==1.8.0
 openccu-data>=2026.6.1
-openccu-loom-client==2026.7.11
+openccu-loom-client==2026.7.12
 mypy<=2.1.0
 prek==0.4.9
 pur==7.4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,14 +1,14 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.47.0
-aiohomematic-test-support==2026.7.6
+aiohomematic-test-support==2026.7.7
 aiohomematic==2026.7.7
 aiohomematic_config==2026.5.0
 isal==1.8.0
 openccu-data>=2026.6.1
 openccu-loom-client==2026.7.12
 mypy<=2.1.0
-prek==0.4.9
+prek==0.4.10
 pur==7.4.0
 pylint==4.0.6
 pylint_strict_informational==0.1

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
-codespell==2.4.2
+codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.15.21
+ruff==0.15.22
 yamllint==1.38.0


### PR DESCRIPTION
## Summary

New `alarm_control_panel` platform for the **openccu-loom backend**: the daemon (≥ 0.42.0) ships a native, local-first alarm engine and models every alarm area — plus, with ≥ 2 areas, an aggregate master panel — as a first-class panel entity. One HA panel spawns per loom panel.

- **State**: tokens come daemon-computed (`alarmpanel.StateToken`) and map 1:1 onto `AlarmControlPanelState` — nothing is re-derived integration-side.
- **Commands**: `ARM_HOME` → `perimeter`, `ARM_AWAY` → `full`, `ARM_NIGHT`/`ARM_VACATION`/`ARM_CUSTOM_BYPASS` → `night`/`vacation`/`custom`; features derive from each panel's configured modes. The master panel fans out client-side, mirroring the daemon's MQTT `MasterArm` semantics (mode-less areas skipped, disarm hits every area).
- **Attributes**: mode, exit/entry countdown, per-mode readiness (blockers/warnings), last incident, walk-test flag.
- **Lifecycle**: panels removed on the daemon (area deleted / master dematerialising) remove their entity — the client bridges that onto the `DeviceRemovedEvent` path `AioHomematicGenericHubEntity` already serves.
- **Dispatch**: new loom-only `backend_types` tuple `LOOM_DP_ALARM_CONTROL_PANEL` (`_loom_only` helper — there is no aiohomematic class to pair with, the CCU has no alarm engine). Degrades to the empty tuple on a CCU-only install: **the direct-CCU path is untouched**, the platform simply spawns nothing there.
- Codes: the daemon enforces its per-area code policy server-side (403 → HA error toast); the upfront code-prompt UX follows once the daemon exposes the policy on the panel entity (SukramJ/openccu-loom#358).

## Dependencies (draft until released)

- ✅ **aiohomematic 2026.7.7** — released 2026-07-17 (SukramJ/aiohomematic#3296 merged)
- ⛔ **openccu-loom-client 2026.7.12** — client-side alarm surface + categorised `LoomDpAlarmControlPanel` twin (SukramJ/openccu-loom-client#62)

Manifest + requirements_test are already bumped to those versions.

## Test plan

- Full unit suite: 836 passed (against local builds of both dependency branches)
- mypy (all 62 source files), ruff, pylint + prek hooks green
- Smoke-verified end-to-end: `Platform.ALARM_CONTROL_PANEL` lands in `HMIP_LOCAL_PLATFORMS`, the dispatch tuple resolves the loom twin, state/feature mapping validated against a live store panel

