### PR TITLE
feat(loom): alarm panel code-prompt UX from the daemon's effective policy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,21 @@
   to empty on a CCU-only install — aiohomematic has no alarm engine, so the
   direct-CCU path is untouched).
 
+- **Alarm panel code-prompt UX (openccu-loom backend).** The daemon (≥ 0.43.x)
+  now ships the effective per-area code policy on the panel entity
+  (`code_arm_required` / `code_disarm_required` — area policy AND an applicable
+  enabled PIN exists; the master panel aggregates any-area). The panel entity
+  reads it live (policy edits ride `alarm.panel_changed`) and exposes
+  `code_format: NUMBER` while any verb needs a code — HA now prompts exactly
+  when the daemon will demand a code, mirroring the daemon's own MQTT
+  discovery (`code: REMOTE_CODE`). Requires openccu-loom-client 2026.7.13.
+
 ### Dependencies
+
+#### Bump openccu-loom-client to `2026.7.13` (pins `openccu-loom-types==0.1.61`, daemon ≥ 0.43.2)
+
+- Effective code policy on the panel twin, `alarm.v1` capability gate,
+  `alarm.notification` event binding, setup-wizard candidate routes.
 
 #### Bump aiohomematic to `2026.7.7`
 

--- a/custom_components/homematicip_local/alarm_control_panel.py
+++ b/custom_components/homematicip_local/alarm_control_panel.py
@@ -23,7 +23,11 @@ from typing import TYPE_CHECKING, Any, cast, override
 
 from aiohomematic.const import DataPointCategory, DataPointType
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity
-from homeassistant.components.alarm_control_panel.const import AlarmControlPanelEntityFeature, AlarmControlPanelState
+from homeassistant.components.alarm_control_panel.const import (
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+    CodeFormat,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -96,12 +100,6 @@ async def async_setup_entry(
 class AioHomematicAlarmControlPanel(AioHomematicGenericHubEntity, AlarmControlPanelEntity):
     """Representation of the HomematicIP alarm control panel entity (openccu-loom)."""
 
-    # The daemon enforces its per-area code policy server-side either way
-    # (an arm/disarm without a required code answers 403, surfaced as a
-    # toast); the flag only drives HA's code-prompt UX and follows the
-    # panel twin once the daemon exposes the policy on the entity.
-    _attr_code_arm_required = False
-
     def __init__(
         self,
         control_unit: ControlUnit,
@@ -119,7 +117,6 @@ class AioHomematicAlarmControlPanel(AioHomematicGenericHubEntity, AlarmControlPa
         for mode in data_point.supported_modes:
             features |= _FEATURE_BY_MODE.get(mode, AlarmControlPanelEntityFeature(0))
         self._attr_supported_features = features
-        self._attr_code_arm_required = data_point.code_arm_required
 
     @property
     def _panel(self) -> LoomDpAlarmControlPanel:
@@ -135,6 +132,34 @@ class AioHomematicAlarmControlPanel(AioHomematicGenericHubEntity, AlarmControlPa
         except ValueError:
             _LOGGER.debug("Unknown alarm panel state token: %s", self._panel.state)
             return None
+
+    @property
+    @override
+    def code_arm_required(self) -> bool:
+        """
+        Return whether arming prompts for a code.
+
+        Daemon-computed effective policy (openccu-loom-client ≥ 2026.7.13:
+        area policy AND an applicable enabled PIN exists; the master panel
+        aggregates any-area). Live policy edits ride ``alarm.panel_changed``,
+        so this stays a property rather than a spawn-time ``_attr_``.
+        """
+        return self._panel.code_arm_required
+
+    @property
+    @override
+    def code_format(self) -> CodeFormat | None:
+        """
+        Return the code-prompt format: numeric while any verb needs a code.
+
+        Mirrors the daemon's own MQTT discovery (``code: REMOTE_CODE`` — a
+        numeric code validated remotely). ``None`` hides the code field
+        entirely; the daemon still enforces server-side either way (403 →
+        error toast).
+        """
+        if self._panel.code_arm_required or self._panel.code_disarm_required:
+            return CodeFormat.NUMBER
+        return None
 
     @property
     @override

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.6.1",
-    "openccu-loom-client==2026.7.12",
+    "openccu-loom-client==2026.7.13",
     "aiohomematic-config==2026.5.0",
     "aiohomematic==2026.7.7"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.7.7
 aiohomematic_config==2026.5.0
 isal==1.8.0
 openccu-data>=2026.6.1
-openccu-loom-client==2026.7.12
+openccu-loom-client==2026.7.13
 mypy<=2.1.0
 prek==0.4.10
 pur==7.4.0


### PR DESCRIPTION
## Summary

Follow-up to #1210: the daemon (≥ 0.43.x) now ships the **effective per-area code policy** on the panel entity and every `alarm.panel_changed` push (`code_arm_required` / `code_disarm_required` — area policy AND an applicable enabled PIN exists; the master panel aggregates any-area). Implemented upstream as SukramJ/openccu-loom#358, consumed by openccu-loom-client 2026.7.13 (SukramJ/openccu-loom-client#63).

- `code_arm_required` and `code_format` are now **live properties** reading the loom twin — policy edits (code created/deleted, policy switch) ride `alarm.panel_changed` and re-render the entity without a respawn. The spawn-time `_attr_code_arm_required = False` placeholder is gone.
- `code_format` returns `CodeFormat.NUMBER` while arming **or** disarming needs a code, else `None` (no code field). This mirrors the daemon's own MQTT discovery (`code: REMOTE_CODE` — numeric, validated remotely), so both HA integration paths prompt identically.
- The daemon keeps enforcing server-side either way (403 → error toast) — the flags are pure prompt UX.

## Dependencies (draft until released)

- ⛔ **openccu-loom-client 2026.7.13** — code-policy passthrough on the twin (SukramJ/openccu-loom-client#63). Manifest + requirements_test bumped.

## Test plan

- Full unit suite: 836 passed (against the local client branch build)
- mypy + ruff green
- Smoke: entity reports `code_format=None` → daemon pushes `code_arm_required=true` via `alarm.panel_changed` → same entity instance reports `CodeFormat.NUMBER` (live-policy path)