### PR TITLE
fix(loom): stop the unique_id sweep from mangling alarm-panel ids (setup crash-loop)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,66 +1,4 @@
-# Version 2.8.5 (unreleased)
-
-## What's Changed
-
-### Features
-
-- **Alarm control panel (openccu-loom backend only).** The openccu-loom daemon
-  (≥ 0.42.0) ships a native, local-first alarm engine and models every alarm
-  area — plus, with two or more areas, an aggregate master panel — as a
-  first-class panel entity. The new `alarm_control_panel` platform spawns one
-  HA panel per loom panel: state tokens come daemon-computed and map 1:1 onto
-  `AlarmControlPanelState`; the configured protection modes map onto the arm
-  features (`perimeter` → home, `full` → away, `night`, `vacation`, `custom` →
-  custom bypass); live detail (mode, countdown, per-mode readiness, last
-  incident, walk test) lands in the extra state attributes; panels removed on
-  the daemon (area deleted) remove their entity. Dispatch runs on the loom
-  twin alone (`LOOM_DP_ALARM_CONTROL_PANEL`, a loom-only tuple that degrades
-  to empty on a CCU-only install — aiohomematic has no alarm engine, so the
-  direct-CCU path is untouched).
-
-- **Alarm panel code-prompt UX (openccu-loom backend).** The daemon (≥ 0.43.x)
-  now ships the effective per-area code policy on the panel entity
-  (`code_arm_required` / `code_disarm_required` — area policy AND an applicable
-  enabled PIN exists; the master panel aggregates any-area). The panel entity
-  reads it live (policy edits ride `alarm.panel_changed`) and exposes
-  `code_format: NUMBER` while any verb needs a code — HA now prompts exactly
-  when the daemon will demand a code, mirroring the daemon's own MQTT
-  discovery (`code: REMOTE_CODE`). Requires openccu-loom-client 2026.7.13.
-
-### Fixes
-
-- **Setup crash-loop after adding an alarm area (loom backend).** The
-  loom unique_id migration treated the daemon-computed alarm-panel ids
-  (`openccu-loom_alarm_<area>`) as legacy aiohomematic keys and prefixed
-  them with `loom_` — orphaning the live panel entity; once the platform
-  had spawned a correctly keyed duplicate, every subsequent setup died
-  with `ValueError: Unique id ... is already in use` and the whole config
-  entry failed to load. The sweep now skips the backend-agnostic
-  `openccu-loom_` namespace, a repair pass renames damaged entries back
-  (removing the history-less duplicate so the original entity keeps its
-  entity_id, area and customisations), and both unique_id migrators skip
-  on target collisions instead of aborting the setup.
-
-### Dependencies
-
-#### Bump openccu-loom-client to `2026.7.13` (pins `openccu-loom-types==0.1.61`, daemon ≥ 0.43.2)
-
-- Effective code policy on the panel twin, `alarm.v1` capability gate,
-  `alarm.notification` event binding, setup-wizard candidate routes.
-
-#### Bump aiohomematic to `2026.7.7`
-
-- Adds the `ALARM_CONTROL_PANEL` category/type vocabulary the platform list
-  derives from (pure vocabulary, no behaviour change on the CCU path).
-
-#### Bump openccu-loom-client to `2026.7.12` (pins `openccu-loom-types==0.1.56`)
-
-- Full client-side alarm surface: `/alarm` REST facade, nine `alarm.*`
-  WebSocket events, store panel section, the categorised
-  `LoomDpAlarmControlPanel` twin and the refresh/removal bridging this
-  platform consumes.
-
-# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-15)
+# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-18)
 
 ## What's Changed
 
@@ -70,9 +8,13 @@
 
 ### Dependencies
 
-#### Bump openccu-loom-client to `2026.7.10` (pins `openccu-loom-types==0.1.55`)
+#### Bump aiohomematic to [2026.7.7](https://github.com/SukramJ/aiohomematic/compare/2026.7.6...2026.7.7)
 
-- Groundwork bump for the still-disabled openccu-loom backend; it has no runtime effect while the backend master switch (`LOOM_BACKEND_SELECTABLE` in `const.py`) stays off. Advances the bundled loom client from `2026.7.6` to `2026.7.10` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.1.55`
+- Adds the `ALARM_CONTROL_PANEL` category/type vocabulary — pure vocabulary, no behaviour change on the CCU path
+
+#### Bump openccu-loom-client to `2026.7.12` (pins `openccu-loom-types==0.1.56`)
+
+- Groundwork bump for the still-disabled openccu-loom backend; it has no runtime effect while the backend master switch (`LOOM_BACKEND_SELECTABLE` in `const.py`) stays off. Advances the bundled loom client from `2026.7.6` to `2026.7.12` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.1.56`
 
 #### homematicip-local-frontend
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,20 @@
   when the daemon will demand a code, mirroring the daemon's own MQTT
   discovery (`code: REMOTE_CODE`). Requires openccu-loom-client 2026.7.13.
 
+### Fixes
+
+- **Setup crash-loop after adding an alarm area (loom backend).** The
+  loom unique_id migration treated the daemon-computed alarm-panel ids
+  (`openccu-loom_alarm_<area>`) as legacy aiohomematic keys and prefixed
+  them with `loom_` — orphaning the live panel entity; once the platform
+  had spawned a correctly keyed duplicate, every subsequent setup died
+  with `ValueError: Unique id ... is already in use` and the whole config
+  entry failed to load. The sweep now skips the backend-agnostic
+  `openccu-loom_` namespace, a repair pass renames damaged entries back
+  (removing the history-less duplicate so the original entity keeps its
+  entity_id, area and customisations), and both unique_id migrators skip
+  on target collisions instead of aborting the setup.
+
 ### Dependencies
 
 #### Bump openccu-loom-client to `2026.7.13` (pins `openccu-loom-types==0.1.61`, daemon ≥ 0.43.2)

--- a/custom_components/homematicip_local/__init__.py
+++ b/custom_components/homematicip_local/__init__.py
@@ -344,6 +344,13 @@ def _loom_migrated_unique_id(unique_id: str, *, entry_suffix: str, serial_suffix
         return None
     if key.endswith("_create_backup") or key.startswith("event_group_"):
         return None
+    if key.startswith("openccu-loom_"):
+        # Daemon-computed ids (the alarm panels: ``openccu-loom_alarm_<area>``)
+        # are deliberately NOT loom_-routing-scheme keys and never existed on
+        # the CCU backend — there is nothing legacy to migrate. Prefixing them
+        # orphaned the live entity and crash-looped setup once the correctly
+        # keyed duplicate spawned (repaired in _async_migrate_loom_unique_ids).
+        return None
     # Hub / internal / virtual-remote keys carried the entry_id suffix as
     # their prefix; swap it for the CCU serial suffix. Everything else
     # (devices, channels, custom DPs) carried no central prefix.
@@ -372,6 +379,35 @@ async def _async_migrate_loom_unique_ids(hass: HomeAssistant, entry: HomematicCo
         return
     entry_suffix = entry.entry_id[-10:]
     serial_suffix = serial[-10:].lower()
+    entity_registry = er.async_get(hass)
+
+    # Repair the damage a pre-fix sweep did to alarm panels: it treated the
+    # daemon-computed ``openccu-loom_alarm_<area>`` ids as legacy keys and
+    # prefixed ``loom_`` — orphaning the original entity (which keeps the
+    # user's entity_id, history, area and customisations) and crash-looping
+    # setup with "unique id already in use" once the platform had spawned a
+    # correctly keyed duplicate. Strip the wrong prefix back off; a duplicate
+    # spawned in the meantime loses (it is the one without history).
+    wrong_prefix = f"{DOMAIN}_loom_openccu-loom_"
+    for entity_entry in list(er.async_entries_for_config_entry(entity_registry, entry.entry_id)):
+        if not entity_entry.unique_id.startswith(wrong_prefix):
+            continue
+        corrected = f"{DOMAIN}_openccu-loom_{entity_entry.unique_id[len(wrong_prefix) :]}"
+        duplicate_id = entity_registry.async_get_entity_id(entity_entry.domain, entity_entry.platform, corrected)
+        if duplicate_id is not None and duplicate_id != entity_entry.entity_id:
+            _LOGGER.warning(
+                "Removing duplicate %s so %s can reclaim its unique_id %s",
+                duplicate_id,
+                entity_entry.entity_id,
+                corrected,
+            )
+            entity_registry.async_remove(duplicate_id)
+        _LOGGER.warning(
+            "Repairing wrongly migrated alarm-panel unique_id: %s -> %s",
+            entity_entry.unique_id,
+            corrected,
+        )
+        entity_registry.async_update_entity(entity_entry.entity_id, new_unique_id=corrected)
 
     @callback
     def _migrator(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
@@ -381,6 +417,16 @@ async def _async_migrate_loom_unique_ids(hass: HomeAssistant, entry: HomematicCo
             serial_suffix=serial_suffix,
         )
         if new_unique_id is None or new_unique_id == entity_entry.unique_id:
+            return None
+        # HA raises on a duplicate unique_id, which would abort the whole
+        # migration and fail the config-entry setup — skip instead (same
+        # guard as _async_realign_hub_unique_ids).
+        if entity_registry.async_get_entity_id(entity_entry.domain, entity_entry.platform, new_unique_id):
+            _LOGGER.warning(
+                "Skipping loom unique_id migration, target already exists: %s -> %s",
+                entity_entry.unique_id,
+                new_unique_id,
+            )
             return None
         _LOGGER.debug(
             "Migrating unique_id to loom scheme: %s -> %s",
@@ -426,10 +472,22 @@ async def _async_restore_aiohomematic_unique_ids(hass: HomeAssistant, entry: Hom
     idempotent, and scoped to this entry, so it is safe to run on every setup.
     """
 
+    entity_registry = er.async_get(hass)
+
     @callback
     def _migrator(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
         new_unique_id = _aiohomematic_restored_unique_id(entity_entry.unique_id)
         if new_unique_id is None or new_unique_id == entity_entry.unique_id:
+            return None
+        # HA raises on a duplicate unique_id, which would abort the whole
+        # migration and fail the config-entry setup — skip instead (same
+        # guard as _async_realign_hub_unique_ids).
+        if entity_registry.async_get_entity_id(entity_entry.domain, entity_entry.platform, new_unique_id):
+            _LOGGER.warning(
+                "Skipping aiohomematic unique_id restore, target already exists: %s -> %s",
+                entity_entry.unique_id,
+                new_unique_id,
+            )
             return None
         _LOGGER.debug(
             "Restoring unique_id to aiohomematic scheme: %s -> %s",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,6 +14,7 @@ import custom_components.homematicip_local
 from custom_components.homematicip_local import (
     _aiohomematic_restored_unique_id,
     _async_migrate_aiohomematic_hub_unique_ids,
+    _async_migrate_loom_unique_ids,
     _async_reanchor_hub_unique_ids_on_serial_change,
     _async_restore_aiohomematic_unique_ids,
     _loom_migrated_unique_id,
@@ -755,6 +756,11 @@ class TestLoomUniqueIdMigration:
             f"{_D}_loom_vcu1234567_1_state",  # already migrated → idempotent
             f"{_D}_home_create_backup",  # synthetic backup button
             f"{_D}_event_group_keypress_vcu1234567_1",  # event group (loom n/a yet)
+            # Daemon-computed alarm-panel ids are backend-agnostic — never
+            # legacy keys. Prefixing them orphaned the entity and
+            # crash-looped setup ("unique id already in use").
+            f"{_D}_openccu-loom_alarm_55f96726-76d9-43b9-8b20-71f6266e24d9",
+            f"{_D}_openccu-loom_alarm_master",
             "other_integration_xyz",  # not ours
         ],
     )
@@ -899,6 +905,104 @@ class TestRealignedHubUniqueId:
 
     def _realign(self, unique_id: str) -> str | None:
         return realign_hub_unique_id(unique_id, central_id=self._NEW)
+
+
+async def test_async_migrate_loom_unique_ids_repairs_wrongly_prefixed_panel(hass: HomeAssistant) -> None:
+    """The repair sweep restores a wrongly loom_-prefixed panel and removes its duplicate.
+
+    Regression: the pre-fix sweep prefixed the daemon-computed alarm-panel
+    ids with loom_, orphaning the original entity; once the platform had
+    spawned a correctly keyed duplicate, the next setup crash-looped with
+    "Unique id ... is already in use".
+    """
+    serial = "3014F711A0001234"
+    entry = MockConfigEntry(domain=HMIP_DOMAIN, unique_id=serial)
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    area = "55f96726-76d9-43b9-8b20-71f6266e24d9"
+    correct_unique_id = f"{HMIP_DOMAIN}_openccu-loom_alarm_{area}"
+    # The original entity, wrongly renamed by the pre-fix sweep — it keeps
+    # the user's entity_id, history and customisations and must win.
+    original = entity_registry.async_get_or_create(
+        domain="alarm_control_panel",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_loom_openccu-loom_alarm_{area}",
+        config_entry=entry,
+        suggested_object_id="ottoloom_obergeschoss",
+    )
+    # The duplicate the platform spawned after the original stopped matching.
+    duplicate = entity_registry.async_get_or_create(
+        domain="alarm_control_panel",
+        platform=HMIP_DOMAIN,
+        unique_id=correct_unique_id,
+        config_entry=entry,
+        suggested_object_id="ottoloom_obergeschoss_2",
+    )
+    # A genuine legacy key must still migrate in the same pass.
+    legacy = entity_registry.async_get_or_create(
+        domain="switch",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_vcu1234567_1_state",
+        config_entry=entry,
+    )
+
+    await _async_migrate_loom_unique_ids(hass, entry)
+
+    assert entity_registry.async_get(duplicate.entity_id) is None
+    repaired = entity_registry.async_get(original.entity_id)
+    assert repaired is not None
+    assert repaired.unique_id == correct_unique_id
+    migrated = entity_registry.async_get(legacy.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == f"{HMIP_DOMAIN}_loom_vcu1234567_1_state"
+
+
+async def test_async_migrate_loom_unique_ids_repairs_without_duplicate(hass: HomeAssistant) -> None:
+    """A damaged panel with no duplicate is renamed straight back."""
+    serial = "3014F711A0001234"
+    entry = MockConfigEntry(domain=HMIP_DOMAIN, unique_id=serial)
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    original = entity_registry.async_get_or_create(
+        domain="alarm_control_panel",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_loom_openccu-loom_alarm_master",
+        config_entry=entry,
+    )
+
+    await _async_migrate_loom_unique_ids(hass, entry)
+
+    repaired = entity_registry.async_get(original.entity_id)
+    assert repaired is not None
+    assert repaired.unique_id == f"{HMIP_DOMAIN}_openccu-loom_alarm_master"
+
+
+async def test_async_migrate_loom_unique_ids_skips_on_collision(hass: HomeAssistant) -> None:
+    """A legacy key whose loom target is already taken is skipped, not fatal."""
+    serial = "3014F711A0001234"
+    entry = MockConfigEntry(domain=HMIP_DOMAIN, unique_id=serial)
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    legacy = entity_registry.async_get_or_create(
+        domain="switch",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_vcu1234567_1_state",
+        config_entry=entry,
+    )
+    occupant = entity_registry.async_get_or_create(
+        domain="switch",
+        platform=HMIP_DOMAIN,
+        unique_id=f"{HMIP_DOMAIN}_loom_vcu1234567_1_state",
+        config_entry=entry,
+    )
+
+    # Must not raise ("unique id already in use" would fail the whole setup).
+    await _async_migrate_loom_unique_ids(hass, entry)
+
+    unchanged = entity_registry.async_get(legacy.entity_id)
+    assert unchanged is not None
+    assert unchanged.unique_id == f"{HMIP_DOMAIN}_vcu1234567_1_state"
+    assert entity_registry.async_get(occupant.entity_id) is not None
 
 
 async def test_async_restore_aiohomematic_unique_ids_rewrites_registry(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

**Hotfix** for the loom-backend setup crash-loop reported after adding an alarm area:

```
ValueError: Unique id 'homematicip_local_loom_openccu-loom_alarm_<area>' is already in use by 'alarm_control_panel.…'
```

### Root cause

`_loom_migrated_unique_id` treats every non-`loom_` key as a legacy aiohomematic routing key and prefixes `loom_`. The alarm-panel ids are **daemon-computed** (`openccu-loom_alarm_<area>`, deliberately not the `loom_` routing scheme — #1210) and never existed on the CCU backend, so there is nothing legacy about them. Sequence of the damage:

1. First restart after a panel spawned: the sweep renames the panel's registry entry to the bogus `…_loom_openccu-loom_alarm_<area>` — the live entity orphans.
2. The platform spawns a correctly keyed duplicate (`…_2` entity_id, no history).
3. Every restart from then on: the sweep tries to rename the duplicate onto the occupied bogus id → `ValueError` escapes `async_migrate_entries` → **the whole config entry fails to set up**, permanently.

### Fix (three parts)

- **Skip the namespace**: `_loom_migrated_unique_id` returns `None` for `openccu-loom_*` keys.
- **Repair the damage**: a pass in `_async_migrate_loom_unique_ids` renames damaged entries back to their correct id, removing the history-less duplicate first — the original entity keeps its entity_id, history, area and customisations.
- **Never abort setup again**: both unique_id migrators (loom + aiohomematic-restore) now skip on target collisions (same guard `_async_realign_hub_unique_ids` already had) instead of letting the `ValueError` kill the config entry.

Works against current main pins (openccu-loom-client 2026.7.12) — no dependency on unreleased packages; independent of #1211.

## Test plan

- 3 new async registry tests: repair with duplicate (original wins, duplicate removed, legacy keys still migrate in the same pass), repair without duplicate, collision skip (no raise)
- 2 new parametrized cases pinning `openccu-loom_alarm_*` / `openccu-loom_alarm_master` as untouched
- Full unit suite: 841 passed; ruff + mypy green