### PR TITLE
fix(event): standard 'ring' event type for doorbells + full DeviceInfo for event entities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Integration
 
 - Doorbell event entities (HmIP-DBB, HmIP-DSD-PCB) now expose and fire the standard `ring` event type instead of `press_short` (#3300). Home Assistant requires doorbell event entities to support `ring` (deprecation warning today, mandatory from HA 2027.4) and its new doorbell triggers listen for it. Other event types such as `press_long` are unchanged, as are the device triggers. **Breaking:** automations that trigger on the `press_short` event type of these _event entities_ must be switched to `ring`
+- Event entities now carry the full device identity (name, manufacturer, model, serial number, firmware) in their `DeviceInfo`. Previously they registered only the device identifiers — if an event entity happened to be the device's first registration, the device entry was created without a name and the generated (sticky) entity_id degraded to the config-entry title (e.g. `event.<instance_name>_ch1` instead of `event.<device_name>_ch1`)
 
 ### Development
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## What's Changed
 
+### Integration
+
+- Doorbell event entities (HmIP-DBB, HmIP-DSD-PCB) now expose and fire the standard `ring` event type instead of `press_short` (#3300). Home Assistant requires doorbell event entities to support `ring` (deprecation warning today, mandatory from HA 2027.4) and its new doorbell triggers listen for it. Other event types such as `press_long` are unchanged, as are the device triggers. **Breaking:** automations that trigger on the `press_short` event type of these _event entities_ must be switched to `ring`
+
 ### Development
 
 - Added a `Makefile` as the entry point for all development tasks (`make help` lists every target): setup, code quality (ruff, mypy, pylint, bandit, codespell, yamllint, prettier, translations, prek), tests (incl. coverage, CI mode and the opt-in e2e suite), hassfest/HACS validation, running Home Assistant against `./config`, and housekeeping. Targets run through `script/run-in-env.sh`, so they work with or without an activated virtual environment. `CLAUDE.md` and `CONTRIBUTING.md` document the targets; the broken `cov.sh` (it referenced a non-existent `.coveragerc`) is superseded by `make test-cov-html` and was removed

--- a/custom_components/homematicip_local/event.py
+++ b/custom_components/homematicip_local/event.py
@@ -6,9 +6,9 @@ import logging
 from typing import Final
 
 from aiohomematic.central.events import DataPointStateChangedEvent, DeviceRemovedEvent, SubscriptionGroup
-from aiohomematic.const import DATA_POINT_EVENTS, DataPointCategory
+from aiohomematic.const import DATA_POINT_EVENTS, DataPointCategory, Parameter
 from aiohomematic.interfaces import ChannelEventGroupProtocol
-from homeassistant.components.event import EventEntity
+from homeassistant.components.event import DoorbellEventType, EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -23,6 +23,11 @@ from .entity_helpers.base import HmEventEntityDescription
 from .entity_helpers.registry import REGISTRY
 
 _LOGGER = logging.getLogger(__name__)
+
+# The Homematic keypress that represents the ring on doorbell devices. HA requires
+# doorbell event entities to support the standard 'ring' event type (mandatory from
+# HA 2027.4), so this type is exposed and fired as 'ring' instead of 'press_short'.
+_DOORBELL_RING_SOURCE: Final = Parameter.PRESS_SHORT.lower()
 
 
 async def async_setup_entry(
@@ -93,6 +98,11 @@ class AioHomematicEvent(EventEntity):
         )
         if isinstance(description, HmEventEntityDescription) and description.device_class is not None:
             self._attr_device_class = description.device_class
+            if description.device_class == EventDeviceClass.DOORBELL:
+                self._attr_event_types = [
+                    DoorbellEventType.RING if event_type == _DOORBELL_RING_SOURCE else event_type
+                    for event_type in self._attr_event_types
+                ]
 
         self._attr_unique_id = f"{DOMAIN}_{event_group.unique_id}"
         # Carry the room: HA applies suggested_area only when the device
@@ -168,7 +178,10 @@ class AioHomematicEvent(EventEntity):
         # Don't update disabled entities
         if self.enabled:
             if triggered := self._event_group.last_triggered_event:
-                self._trigger_event(triggered.parameter.lower())
+                event_type = triggered.parameter.lower()
+                if self.device_class == EventDeviceClass.DOORBELL and event_type == _DOORBELL_RING_SOURCE:
+                    event_type = DoorbellEventType.RING
+                self._trigger_event(event_type)
                 _LOGGER.debug("Device event emitted %s", self.name)
                 self.async_schedule_update_ha_state()
         else:

--- a/custom_components/homematicip_local/event.py
+++ b/custom_components/homematicip_local/event.py
@@ -105,13 +105,22 @@ class AioHomematicEvent(EventEntity):
                 ]
 
         self._attr_unique_id = f"{DOMAIN}_{event_group.unique_id}"
-        # Carry the room: HA applies suggested_area only when the device
-        # entry is first created — if this event entity happens to be the
-        # device's first, a bare DeviceInfo would pin the device area-less
-        # forever (suggested_area is runtime-only and never re-applied).
+        # Carry the full device identity, not just the identifiers: if this
+        # event entity happens to be the device's first registration, a bare
+        # DeviceInfo would create the device entry without a name — the
+        # generated (sticky) entity_id then degrades to the config-entry
+        # title — and pin it area-less forever (suggested_area is
+        # runtime-only and never re-applied after creation).
+        hm_device = event_group.device
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, event_group.device.identifier)},
-            suggested_area=event_group.device.room,
+            identifiers={(DOMAIN, hm_device.identifier)},
+            manufacturer=hm_device.manufacturer,
+            model=hm_device.model,
+            model_id=hm_device.model_description,
+            name=hm_device.name,
+            serial_number=hm_device.address,
+            sw_version=hm_device.firmware,
+            suggested_area=hm_device.room,
         )
         self._attr_extra_state_attributes = {
             EVENT_INTERFACE_ID: event_group.device.interface_id,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,109 @@
+"""Tests for event entities of Homematic(IP) Local."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from homeassistant.components.event import DoorbellEventType
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests import const
+from tests.helper import Factory
+
+TEST_DEVICES: dict[str, str] = {
+    "VCU4567298": "HmIP-DBB.json",
+    "VCU7935803": "HMIP-WRC2.json",
+}
+
+# pylint: disable=protected-access
+
+
+async def _wait_for_entity(*, hass: HomeAssistant, unique_id: str) -> str:
+    """
+    Poll until the event entity with the given unique_id appears and return its entity_id.
+
+    Event entities are added via dispatcher after platform setup, and their
+    entity_id depends on registration order (the device may not carry its
+    name yet), so the entity is resolved via the registry instead of by a
+    hard-coded entity_id.
+    """
+    registry = er.async_get(hass)
+    async with asyncio.timeout(2):
+        while (
+            entity_id := registry.async_get_entity_id("event", "homematicip_local", unique_id)
+        ) is None or hass.states.get(entity_id) is None:
+            await hass.async_block_till_done()
+            await asyncio.sleep(0.01)
+    return entity_id
+
+
+async def _wait_for_event_type(*, hass: HomeAssistant, entity_id: str, expected: str) -> None:
+    """
+    Poll until the entity's last event_type matches the expected one.
+
+    The chain GenericEvent -> ChannelEventGroup -> entity crosses two
+    aiohomematic task hops that HA's block_till_done does not track, so a
+    fixed number of loop ticks is not deterministic. Raises TimeoutError
+    when the event never arrives.
+    """
+    async with asyncio.timeout(2):
+        while (state := hass.states.get(entity_id)) is None or state.attributes["event_type"] != expected:
+            await hass.async_block_till_done()
+            await asyncio.sleep(0.01)
+
+
+class TestAioHomematicEvent:
+    """Tests for AioHomematicEvent entities."""
+
+    @pytest.mark.asyncio
+    async def test_doorbell_event_declares_and_fires_ring(
+        self,
+        factory_homegear: Factory,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A doorbell event entity declares and fires 'ring' instead of 'press_short'."""
+        hass, control = await factory_homegear.setup_environment(TEST_DEVICES)
+        entity_id = await _wait_for_entity(hass=hass, unique_id="homematicip_local_event_group_keypress_vcu4567298_1")
+        # HA warns on add when a doorbell event entity lacks the 'ring' event
+        # type (and rejects it from HA 2027.4) - see issue #3300.
+        assert "is a doorbell event entity but does not support" not in caplog.text
+        ha_state = hass.states.get(entity_id)
+        assert ha_state.attributes["device_class"] == "doorbell"
+
+        event_types = ha_state.attributes["event_types"]
+        assert DoorbellEventType.RING in event_types
+        assert "press_short" not in event_types
+        assert "press_long" in event_types
+
+        await control.central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU4567298:1", parameter="PRESS_SHORT", value=True
+        )
+        await _wait_for_event_type(hass=hass, entity_id=entity_id, expected=DoorbellEventType.RING)
+
+        await control.central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU4567298:1", parameter="PRESS_LONG", value=True
+        )
+        await _wait_for_event_type(hass=hass, entity_id=entity_id, expected="press_long")
+
+    @pytest.mark.asyncio
+    async def test_non_doorbell_event_keeps_native_event_types(
+        self,
+        factory_homegear: Factory,
+    ) -> None:
+        """A non-doorbell keypress entity keeps the native Homematic event types."""
+        hass, control = await factory_homegear.setup_environment(TEST_DEVICES)
+        entity_id = await _wait_for_entity(hass=hass, unique_id="homematicip_local_event_group_keypress_vcu7935803_1")
+        ha_state = hass.states.get(entity_id)
+        assert ha_state.attributes["device_class"] == "button"
+
+        event_types = ha_state.attributes["event_types"]
+        assert "press_short" in event_types
+        assert DoorbellEventType.RING not in event_types
+
+        await control.central.event_coordinator.data_point_event(
+            interface_id=const.INTERFACE_ID, channel_address="VCU7935803:1", parameter="PRESS_SHORT", value=True
+        )
+        await _wait_for_event_type(hass=hass, entity_id=entity_id, expected="press_short")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.components.event import DoorbellEventType
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import async_get_platforms
 
 from tests import const
 from tests.helper import Factory
@@ -87,6 +88,35 @@ class TestAioHomematicEvent:
             interface_id=const.INTERFACE_ID, channel_address="VCU4567298:1", parameter="PRESS_LONG", value=True
         )
         await _wait_for_event_type(hass=hass, entity_id=entity_id, expected="press_long")
+
+    @pytest.mark.asyncio
+    async def test_event_device_info_carries_device_name(
+        self,
+        factory_homegear: Factory,
+    ) -> None:
+        """
+        Event entities carry the device name in their DeviceInfo.
+
+        When the event platform registers its entities before any other
+        platform creates the device entry, a name-less DeviceInfo would
+        create the device without a name and the generated (sticky)
+        entity_id degrades to the config-entry title (e.g.
+        event.centraltest_ch1).
+        """
+        hass, _control = await factory_homegear.setup_environment(TEST_DEVICES)
+        entity_id = await _wait_for_entity(hass=hass, unique_id="homematicip_local_event_group_keypress_vcu4567298_1")
+
+        entity = next(
+            entity
+            for platform in async_get_platforms(hass, "homematicip_local")
+            for entity in platform.entities.values()
+            if entity.entity_id == entity_id
+        )
+        device_info = entity.device_info
+        assert device_info is not None
+        assert device_info.get("name") == "HmIP-DBB_VCU4567298"
+        assert device_info.get("model") == "HmIP-DBB"
+        assert device_info.get("serial_number") == "VCU4567298"
 
     @pytest.mark.asyncio
     async def test_non_doorbell_event_keeps_native_event_types(


### PR DESCRIPTION
## Summary

Two fixes for the event platform. The first fixes the HA deprecation warning reported in sukramj/aiohomematic#3300; the second fixes a registration-order race found while writing the tests for the first.

### 1. Doorbell entities expose and fire the standard `ring` event type

> Entity ... is a doorbell event entity but does not support the 'ring' event type. This will stop working in Home Assistant 2027.4

HA requires event entities with `device_class: doorbell` to support the standard `DoorbellEventType.RING` (checked on entity add since HA 2026.7, mandatory from 2027.4; the new `doorbell` component triggers listen for it). Our doorbell event entities (HmIP-DBB, HmIP-DSD-PCB) exposed the raw Homematic keypress types (`press_short`/`press_long`) instead.

For doorbell event entities, `press_short` is now mapped to `ring` in both the declared `event_types` and the fired event. Other event types (`press_long`) and the device triggers are unchanged. This follows the pattern HA core applied to its own integrations (nest #169691, unifiprotect, unifi_access).

**Breaking** for automations that trigger on the `press_short` event type of these event entities — they must be switched to `ring`.

### 2. Event entities carry the full device identity in `DeviceInfo`

Event entities registered only the device identifiers plus `suggested_area`. If an event entity happened to be the device's **first** registration, the device entry was created without a name and the generated (sticky) entity_id degraded to the config-entry title (e.g. `event.centraltest_ch1` instead of `event.hmip_dbb_..._ch1`). The `DeviceInfo` now includes name, manufacturer, model, model_id, serial_number and sw_version — the same values the generic entities register, so the merged device entry is identical regardless of registration order.

## Testing

- `tests/test_event.py` (new, test-first): doorbell entity declares/fires `ring` and no longer triggers the HA warning; a non-doorbell keypress entity (HMIP-WRC2) keeps its native event types; the event entity's `DeviceInfo` carries the device name/model/serial. Entities are resolved via unique_id and event propagation is polled, since the entity_id depends on registration order and the event chain crosses two aiohomematic task hops.
- Full suite: 844 passed, 6 skipped. Doorbell tests stable across 15 consecutive runs.
- `prek` hooks on the touched files: passed.