### PR TITLE
feat(event): doorbell model list from openccu-data's curated device semantics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Version 2.8.5 (unreleased)
+
+## What's Changed
+
+### Integration
+
+- The doorbell device list now comes from openccu-data's curated `device_semantics` extract (via `aiohomematic.device_semantics.DOORBELL_MODELS`, aiohomematic 2026.7.9) instead of a hardcoded tuple — one source of truth shared with openccu-loom's MQTT discovery. The classic `HM-Sen-DB-PCB` joins `HmIP-DBB` and `HmIP-DSD-PCB`: its short press now fires the standard `ring` event type on its doorbell event entity (#3300 follow-up)
+
 # Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-18)
 
 ## What's Changed

--- a/custom_components/homematicip_local/entity_helpers/descriptions/events.py
+++ b/custom_components/homematicip_local/entity_helpers/descriptions/events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from aiohomematic.const import DataPointCategory
+from aiohomematic.device_semantics import DOORBELL_MODELS
 from custom_components.homematicip_local.entity_helpers.factories import event
 from custom_components.homematicip_local.entity_helpers.registry import EntityDescriptionRule
 from homeassistant.components.event import EventDeviceClass
@@ -10,9 +11,11 @@ from homeassistant.components.event import EventDeviceClass
 EVENT_RULES: list[EntityDescriptionRule] = [
     EntityDescriptionRule(
         category=DataPointCategory.EVENT_GROUP,
-        # HmIP-DBB: wireless doorbell button. HmIP-DSD-PCB: doorbell sensor PCB whose
-        # input channel signals a ring — both are doorbells, not generic buttons.
-        devices=("HmIP-DBB", "HmIP-DSD-PCB"),
+        # Devices whose press/ring channel is a doorbell rather than a generic
+        # button — sourced from openccu-data's curated device_semantics extract
+        # (the same list openccu-loom's MQTT discovery embeds): HM-Sen-DB-PCB,
+        # HmIP-DBB, HmIP-DSD-PCB.
+        devices=tuple(sorted(DOORBELL_MODELS)),
         description=event(
             key="event_doorbell",
             device_class=EventDeviceClass.DOORBELL,

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/sukramj/aiohomematic/issues",
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
-    "openccu-data==2026.6.1",
+    "openccu-data==2026.7.0",
     "openccu-loom-client==2026.7.13",
     "aiohomematic-config==2026.5.0",
     "aiohomematic==2026.7.9"

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -14,7 +14,7 @@
     "openccu-data==2026.6.1",
     "openccu-loom-client==2026.7.13",
     "aiohomematic-config==2026.5.0",
-    "aiohomematic==2026.7.7"
+    "aiohomematic==2026.7.9"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,11 +1,11 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.47.0
-aiohomematic-test-support==2026.7.7
-aiohomematic==2026.7.7
+aiohomematic-test-support==2026.7.9
+aiohomematic==2026.7.9
 aiohomematic_config==2026.5.0
 isal==1.8.0
-openccu-data>=2026.6.1
+openccu-data>=2026.7.0
 openccu-loom-client==2026.7.13
 mypy<=2.1.0
 prek==0.4.10


### PR DESCRIPTION
Follow-up to #1213 / SukramJ/aiohomematic#3300: the doorbell rule's device tuple now comes from `aiohomematic.device_semantics.DOORBELL_MODELS` (openccu-data's new curated `device_semantics` extract, SukramJ/openccu-data#19) instead of a hardcoded list — one source of truth shared with openccu-loom's MQTT HA discovery, which embeds the same list Go-side.

The classic **HM-Sen-DB-PCB** joins `HmIP-DBB` and `HmIP-DSD-PCB`: its short press now fires the standard `ring` event type on its doorbell event entity.

⚠️ **Merge order:** openccu-data 2026.7.0 → aiohomematic 2026.7.9 (SukramJ/aiohomematic#3304) → this PR (manifest pins aiohomematic==2026.7.9); CI fails on dependency resolution until the chain is released.