### PR TITLE
chore(deps): bump aiohomematic to 2026.7.11, openccu-data to 2026.7.1, loom client to 2026.7.16

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types_or: [python]
         files: ^(custom_components/homematicip_local|tests)/.+\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff
         args:

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-20)
+# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-26)
 
 ## What's Changed
 
@@ -14,19 +14,21 @@
 
 ### Dependencies
 
-#### Bump aiohomematic to [2026.7.10](https://github.com/SukramJ/aiohomematic/compare/2026.7.6...2026.7.10)
+#### Bump aiohomematic to [2026.7.11](https://github.com/SukramJ/aiohomematic/compare/2026.7.6...2026.7.11)
 
+- Fix XML-RPC commands hanging forever when a connection goes half-open. The operational XML-RPC proxy is now created with a socket timeout (`rpc_timeout`, 60 s by default), matching backend detection; previously it had none, so a silently dropped or half-open (TLS) keep-alive connection made a `setValue`/`putParamset` block indefinitely in the proxy's single worker thread. Since each interface has exactly one worker, that wedged the interface's entire outgoing command path until Home Assistant was restarted — commands were neither sent nor failed, the only visible symptom being the 30 s optimistic rollback, while incoming events kept arriving over the separate callback path. A stuck request now aborts as a retryable `NoConnectionException`, which frees the worker thread and lets the command retry handler react
 - Fix data point names getting a redundant `ch<no>` postfix even when the channel's custom name is already unique (#3313). The postfix for parameters that exist on multiple channels of a device is now only appended when the channel name alone does not identify the channel — device-derived names, names following the `<name>:<no>` scheme, or several same-named channels providing the same parameter. A channel with a unique custom name (e.g. a status channel named `<sub device> Status`) keeps its clean entity name again
 - New `aiohomematic.device_semantics` module exposing the curated device-semantics classifications from openccu-data — first classification: `DOORBELL_MODELS`, the basis for the doorbell-model change above (#3304)
 - Adds the `ALARM_CONTROL_PANEL` category/type vocabulary — pure vocabulary, no behaviour change on the CCU path
 
-#### Bump openccu-data to [2026.7.0](https://github.com/SukramJ/openccu-data/compare/2026.6.1...2026.7.0)
+#### Bump openccu-data to [2026.7.1](https://github.com/SukramJ/openccu-data/compare/2026.6.1...2026.7.1)
 
 - Adds the curated `device_semantics` extract (doorbell classification) that aiohomematic's new `device_semantics` module reads
+- Regenerates the easymode and translation extracts as well as the `BLIND_VIRTUAL_RECEIVER`, `SHUTTER_VIRTUAL_RECEIVER` and `WATER_SWITCH_VIRTUAL_RECEIVER` profiles from the latest OCCU sources: a new `SHORT_OUTPUT_BEHAVIOUR` parameter in the water-switch profiles, `LONG_PROFILE_ACTION_TYPE` narrowed to a fixed value in the blind/shutter profiles, plus revised German/English help texts and value labels
 
-#### Bump openccu-loom-client to `2026.7.14` (pins `openccu-loom-types==0.1.61`)
+#### Bump openccu-loom-client to `2026.7.16` (pins `openccu-loom-types==0.1.68`)
 
-- Groundwork bump for the still-disabled openccu-loom backend; it has no runtime effect while the backend master switch (`LOOM_BACKEND_SELECTABLE` in `const.py`) stays off. Advances the bundled loom client from `2026.7.6` to `2026.7.14` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.1.61`
+- Groundwork bump for the still-disabled openccu-loom backend; it has no runtime effect while the backend master switch (`LOOM_BACKEND_SELECTABLE` in `const.py`) stays off. Advances the bundled loom client from `2026.7.6` to `2026.7.16` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.1.68`
 
 #### homematicip-local-frontend
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -11,10 +11,10 @@
   "issue_tracker": "https://github.com/sukramj/aiohomematic/issues",
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
-    "openccu-data==2026.7.0",
-    "openccu-loom-client==2026.7.15",
+    "openccu-data==2026.7.1",
+    "openccu-loom-client==2026.7.16",
     "aiohomematic-config==2026.5.0",
-    "aiohomematic==2026.7.10"
+    "aiohomematic==2026.7.11"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,15 +1,15 @@
 -r requirements_test_pre_commit.txt
 
-async_upnp_client==0.47.0
-aiohomematic-test-support==2026.7.10
-aiohomematic==2026.7.10
+async_upnp_client==0.48.0
+aiohomematic-test-support==2026.7.11
+aiohomematic==2026.7.11
 aiohomematic_config==2026.5.0
 isal==1.8.0
-openccu-data>=2026.7.0
-openccu-loom-client==2026.7.15
+openccu-data>=2026.7.1
+openccu-loom-client==2026.7.16
 mypy<=2.1.0
-prek==0.4.10
+prek==0.4.11
 pur==7.4.0
 pylint==4.0.6
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.35
+pytest-homeassistant-custom-component-framework==1.0.37

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 bandit==1.9.4
 codespell==2.4.3
 python-typing-update==v0.8.1
-ruff==0.15.22
+ruff==0.16.0
 yamllint==1.38.0

--- a/script/sort_class_members.py
+++ b/script/sort_class_members.py
@@ -246,7 +246,7 @@ def _reorder_methods(methods: list[MethodSeg]) -> list[MethodSeg]:
         setters = [m for m in grp if m.subgroup == "setter"]
         deleters = [m for m in grp if m.subgroup == "deleter"]
         # Determine the kind from the primary getter (if multiple, choose first by name for stability)
-        primary_getter = sorted(getters, key=lambda m: m.name)[0] if getters else None
+        primary_getter = min(getters, key=lambda m: m.name) if getters else None
         kind = primary_getter.prop_kind if primary_getter else None
         prio = PRIORITY_INDEX.get(kind or "", len(PRIORITY))
         # Strict order within a property group: getter(s) -> setter(s) -> deleter(s)


### PR DESCRIPTION
## Summary

Dependency bumps for the upcoming 2.8.4 release, plus the matching changelog update.

### Runtime

- **aiohomematic `2026.7.10` → `2026.7.11`** — the operational XML-RPC proxy is now created with a socket timeout (`rpc_timeout`, 60 s). Previously it had none, so a silently dropped or half-open (TLS) keep-alive connection made a `setValue`/`putParamset` block indefinitely in the proxy's single worker thread, wedging the interface's entire outgoing command path until Home Assistant was restarted (only visible symptom: the 30 s optimistic rollback). A stuck request now aborts as a retryable `NoConnectionException`.
- **openccu-data `2026.7.0` → `2026.7.1`** — regenerated easymode/translation extracts and the `BLIND_`/`SHUTTER_`/`WATER_SWITCH_VIRTUAL_RECEIVER` profiles from the latest OCCU sources (new `SHORT_OUTPUT_BEHAVIOUR`, `LONG_PROFILE_ACTION_TYPE` narrowed to a fixed value, revised help texts and value labels).
- **openccu-loom-client `2026.7.15` → `2026.7.16`** (pins `openccu-loom-types==0.1.68`) — groundwork only; no runtime effect while `LOOM_BACKEND_SELECTABLE` stays off.

The `aiohomematic` pin stays last in `manifest.json`'s `requirements`.

### Test / tooling pins

`async_upnp_client` 0.48.0, `aiohomematic-test-support` 2026.7.11, `ruff` 0.16.0 (also in `.pre-commit-config.yaml`), `prek` 0.4.11, `pytest-homeassistant-custom-component-framework` 1.0.37.

### Changelog

2.8.4 dependency section updated (aiohomematic/openccu-data compare links and entries, loom-client version + types pin corrected — it still listed `2026.7.14`/`0.1.61` while the manifest was already on `2026.7.15`). Release date moved to 2026-07-26. Loom details remain out of scope.

## Test plan

- `make test` → 844 passed, 6 skipped
- prek hooks pass on commit