### PR TITLE
test(config_flow): settle the reauth entry update so no store timer lingers

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import MockConfigEntry, flush_store
 
 from aiohomematic.backend_detection import BackendDetectionResult
 from aiohomematic.const import (
@@ -3150,6 +3150,7 @@ class TestReauthFlow:
                     CONF_PASSWORD: "new_password",
                 },
             )
+            await hass.async_block_till_done()
 
         assert result2["type"] == FlowResultType.ABORT
         assert result2["reason"] == "reauth_successful"
@@ -3157,6 +3158,10 @@ class TestReauthFlow:
         # Verify credentials were updated
         assert entry.data[CONF_USERNAME] == "new_username"
         assert entry.data[CONF_PASSWORD] == "new_password"
+
+        # The entry update schedules a delayed config-entry store write; flush it so
+        # the pending timer does not linger into teardown.
+        await flush_store(hass.config_entries._store)
 
     async def test_reauth_flow_validation_failure(self, hass: HomeAssistant) -> None:
         """Test reauthentication flow with validation failure."""


### PR DESCRIPTION
## Summary

Follow-up to #1217: `test_reauth_flow_success` is flaky on CI.

`async_update_reload_and_abort` schedules **two** things — an entry reload and a delayed config-entry store write. The test asserted the abort result and ended immediately, so on slower CI runners the store write was still pending at teardown and the lingering-timer check errored the test:

```
ERROR tests/test_config_flow.py::TestReauthFlow::test_reauth_flow_success
  Failed: Lingering timer after test <TimerHandle when=201.981620362
  Store._async_schedule_callback_delayed_write() ...>
```

All 844 tests passed in that run — only the teardown check failed, and a plain rerun of the same commit went green, confirming it is a timing race rather than a real regression.

The four `reconfigure_successful` tests in the same file already call `await hass.async_block_till_done()` after the flow; this test did not. It now settles the reload the same way and additionally flushes the config-entry store, so the pending write is executed and its timer cleared deterministically instead of depending on runner speed.

## Test plan

- `tests/test_config_flow.py::TestReauthFlow` → 4 passed
- `make test-ci` → 844 passed, 6 skipped (also run 5× before the fix, green locally every time — the race only shows on CI)
- prek hooks pass