### PR TITLE
feat(config_flow): backend-aware flow titles, in-place backend switch, loom sub-device toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -570,6 +570,11 @@ The integration uses a modern, user-friendly multi-step configuration flow:
 - ✅ **Progress Indicators**: Each step shows "Step X of Y"
 - ✅ **Menu-Based Navigation**: Clear choice between finishing setup or accessing advanced options
 - ✅ **Reconfigure Flow**: Update connection settings without deleting and re-adding integration
+- ✅ **Backend-Aware Flow Titles**: `flow_title` carries a `{backend}` placeholder (`aiohomematic` / `openccu-loom`), so discovery cards (SSDP vs. mDNS), reauth and reconfigure dialogs show which backend a flow targets
+- ✅ **In-Place Backend Switch**: Setting up a CCU whose serial is already configured on the *other* backend switches the existing entry in place (abort reason `backend_switched`) instead of aborting with `already_configured`. The entry keeps its entry_id, instance name and advanced config (incl. `sub_devices_enabled`); the previous backend's connection keys stay in the entry so a switch back is lossless
+- ✅ **Loom Sub-Device Toggle**: The openccu-loom setup flow (manual form and discovered-daemon token step) offers `sub_devices_enabled` directly, defaulting to enabled (`DEFAULT_LOOM_ENABLE_SUB_DEVICES`)
+- ✅ **Serial-Keyed Manual Loom Setup**: The manual loom form validates the daemon, lists its CCUs and routes into the shared CCU-selection step, so manual entries get the same serial-based dedup and in-place backend switch as discovered daemons (the user-chosen instance name is kept)
+- ✅ **Single-Reload Entry Updates**: `_async_update_reload_and_abort_entry` (used by reauth and both backend-switch paths) schedules a reload only when the entry's update listener will not already reload it — never use `ConfigFlow.async_update_reload_and_abort` here (double reload, deprecated with HA 2026.12)
 
 ### Service Registration Pattern
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@
 ### Integration
 
 - Diagnostics download no longer crashes on the openccu-loom backend: the compat adapter exposes neither `device_registry` nor `metrics_aggregator`, so the payload now derives the model list from the registered devices and omits the in-process metrics section instead of raising `AttributeError`
+- Discovery cards now show which backend a discovered instance targets: the flow title carries a `{backend}` placeholder (`aiohomematic` for a CCU found via SSDP, `openccu-loom` for a daemon found via mDNS), so two cards for the same CCU are distinguishable before clicking. Reauth and reconfigure flow titles carry the entry's backend the same way
+- **In-place backend switch**: setting up a CCU whose serial is already configured on the *other* backend no longer aborts with `already_configured` — the existing entry switches backend in place and reloads. The entry keeps its entry_id, instance name and advanced config (incl. `sub_devices_enabled`), so entities, history and customisations survive the CCU ⇄ loom round-trip; the stale connection keys of the previous backend stay in the entry, making a switch back lossless. Adding a serial already configured on the *same* backend still aborts
+- The openccu-loom setup flow (manual form and discovered-daemon token step) now offers **Create sub-device entities** directly, enabled by default; on a backend switch an explicit choice stored on the existing entry wins over the form default
+- The **manual** openccu-loom form now validates the daemon connection, lists its CCUs and routes into the shared CCU-selection step. Manual entries are therefore serial-keyed like discovered ones — duplicate setups abort, the in-place backend switch applies, and auth/connection/no-CCU errors surface on the form. The user-chosen instance name is kept; a blank daemon port stays absent from the entry (the loom client applies its TLS-dependent default)
+- Config entry updates from the reauth and backend-switch flows now reload the entry exactly once: a shared helper schedules a reload only when the registered update listener will not already do so (unloaded entry or unchanged data), replacing `ConfigFlow.async_update_reload_and_abort`, whose extra reload schedule alongside an update listener double-reloaded and is deprecated with HA 2026.12
 
 ### Development
 

--- a/custom_components/homematicip_local/config_flow.py
+++ b/custom_components/homematicip_local/config_flow.py
@@ -35,7 +35,14 @@ from aiohomematic.const import (
     is_interface_default_port,
 )
 from aiohomematic.exceptions import AuthFailure, BaseHomematicException, NoConnectionException, ValidationException
-from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import (
+    CONN_CLASS_LOCAL_PUSH,
+    ConfigEntry,
+    ConfigEntryState,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PATH, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
@@ -100,6 +107,7 @@ from .const import (
     DEFAULT_ENABLE_SUB_DEVICES,
     DEFAULT_ENABLE_SYSTEM_NOTIFICATIONS,
     DEFAULT_LISTEN_ON_ALL_IP,
+    DEFAULT_LOOM_ENABLE_SUB_DEVICES,
     DEFAULT_MQTT_PREFIX,
     DEFAULT_SYS_SCAN_INTERVAL,
     DOMAIN,
@@ -149,6 +157,10 @@ IF_VIRTUAL_DEVICES_PATH: Final = "/groups"
 TEXT_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
 PASSWORD_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
 BOOLEAN_SELECTOR = BooleanSelector()
+
+# User-facing backend labels for the {backend} placeholder in flow_title
+TITLE_BACKEND_CCU: Final = "aiohomematic"
+TITLE_BACKEND_LOOM: Final = "openccu-loom"
 
 # openccu-loom mDNS discovery
 ZEROCONF_TYPE = "_openccu-loom._tcp.local."
@@ -201,7 +213,8 @@ def get_loom_schema(data: ConfigType) -> Schema:
     """Return the openccu-loom daemon connection schema.
 
     The daemon owns interfaces, callback ports and CCU credentials, so
-    the user only supplies the daemon endpoint and a bearer token.
+    the user only supplies the daemon endpoint, a bearer token and the
+    sub-device toggle (enabled by default on the loom backend).
     """
     return vol.Schema(
         {
@@ -211,6 +224,12 @@ def get_loom_schema(data: ConfigType) -> Schema:
             vol.Required(CONF_TLS, default=data.get(CONF_TLS, True)): BOOLEAN_SELECTOR,
             vol.Required(CONF_VERIFY_TLS, default=data.get(CONF_VERIFY_TLS, True)): BOOLEAN_SELECTOR,
             vol.Optional(CONF_LOOM_TOKEN, default=data.get(CONF_LOOM_TOKEN, "")): PASSWORD_SELECTOR,
+            vol.Required(
+                CONF_ENABLE_SUB_DEVICES,
+                default=data.get(CONF_ADVANCED_CONFIG, {}).get(
+                    CONF_ENABLE_SUB_DEVICES, DEFAULT_LOOM_ENABLE_SUB_DEVICES
+                ),
+            ): BOOLEAN_SELECTOR,
         }
     )
 
@@ -245,14 +264,16 @@ def get_loom_options_schema(data: ConfigType) -> Schema:
 
 
 def get_loom_token_schema(data: ConfigType) -> Schema:
-    """Return the token-only schema for a discovered openccu-loom daemon.
+    """Return the schema for a discovered openccu-loom daemon.
 
     Host / port / TLS come from the mDNS advertisement, so the user only
-    supplies the bearer token.
+    supplies the bearer token and the sub-device toggle (enabled by
+    default on the loom backend).
     """
     return vol.Schema(
         {
             vol.Optional(CONF_LOOM_TOKEN, default=data.get(CONF_LOOM_TOKEN, "")): PASSWORD_SELECTOR,
+            vol.Required(CONF_ENABLE_SUB_DEVICES, default=DEFAULT_LOOM_ENABLE_SUB_DEVICES): BOOLEAN_SELECTOR,
         }
     )
 
@@ -386,6 +407,11 @@ def _get_retry_hint(error_type: str) -> str:
         "invalid_config": "check_config_values",
     }
     return hints.get(error_type, "check_settings")
+
+
+def _get_backend_title(*, backend: str | None) -> str:
+    """Return the user-facing backend label for the {backend} flow-title placeholder."""
+    return TITLE_BACKEND_LOOM if backend == BACKEND_LOOM else TITLE_BACKEND_CCU
 
 
 def _get_effective_port(interface: Interface, tls: bool, data: ConfigType) -> int:
@@ -813,6 +839,10 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         # openccu-loom mDNS discovery state (carried across token/CCU steps).
         self._loom_discovery: dict[str, Any] = {}
         self._loom_token: str | None = None
+        self._loom_enable_sub_devices: bool = DEFAULT_LOOM_ENABLE_SUB_DEVICES
+        # User-chosen instance name from the manual loom form; discovered
+        # daemons name the entry after the selected CCU instead.
+        self._loom_instance_name: str | None = None
         self._loom_ccus: list[dict[str, Any]] = []
         self._loom_discovered_daemons: list[dict[str, Any]] = []
         self._loom_skip_browse: bool = False
@@ -1069,7 +1099,12 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_loom(self, user_input: ConfigType | None = None) -> ConfigFlowResult:
-        """Configure an openccu-loom daemon backend (mDNS browse → manual)."""
+        """Configure an openccu-loom daemon backend (mDNS browse → manual).
+
+        The manual form validates the daemon connection, lists its CCUs and
+        routes into the shared CCU-selection step, so manual setups are
+        serial-keyed (dedup, in-place backend switch) like discovered ones.
+        """
         if not LOOM_BACKEND_SELECTABLE:
             return await self.async_step_central(user_input=None)
         # On entry (no input yet) actively browse for daemons and offer a
@@ -1095,7 +1130,9 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_HOST: user_input[CONF_HOST],
                 CONF_TLS: user_input.get(CONF_TLS, True),
                 CONF_VERIFY_TLS: user_input.get(CONF_VERIFY_TLS, True),
-                CONF_ADVANCED_CONFIG: {},
+                CONF_ADVANCED_CONFIG: {
+                    CONF_ENABLE_SUB_DEVICES: user_input.get(CONF_ENABLE_SUB_DEVICES, DEFAULT_LOOM_ENABLE_SUB_DEVICES)
+                },
             }
             if (port := user_input.get(CONF_LOOM_PORT)) is not None:
                 self.data[CONF_LOOM_PORT] = int(port)
@@ -1103,14 +1140,48 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.data[CONF_LOOM_TOKEN] = token
             try:
                 await ControlConfig(hass=self.hass, entry_id="validate", data=self.data).check_config()
-            except (InvalidConfig, BaseHomematicException) as exc:
+                ccus = await _async_loom_list_ccus(
+                    self.hass,
+                    host=self.data[CONF_HOST],
+                    port=self.data.get(CONF_LOOM_PORT),
+                    tls=self.data[CONF_TLS],
+                    token=self.data.get(CONF_LOOM_TOKEN, ""),
+                    base_path=None,
+                )
+            except AuthFailure:
+                errors["base"] = "invalid_auth"
+                description_placeholders["invalid_items"] = self.data.get(CONF_HOST, "")
+            except InvalidConfig as exc:
                 _LOGGER.warning("Loom backend config invalid: %s", exc)
                 errors["base"] = "invalid_config"
-                description_placeholders["invalid_items"] = (exc.args[0] if exc.args else "") or user_input.get(
+                description_placeholders["invalid_items"] = (exc.args[0] if exc.args else "") or self.data.get(
+                    CONF_HOST, ""
+                )
+            except BaseHomematicException as exc:
+                errors["base"] = "cannot_connect"
+                description_placeholders["invalid_items"] = (exc.args[0] if exc.args else "") or self.data.get(
                     CONF_HOST, ""
                 )
             else:
-                return self.async_create_entry(title=self.data[CONF_INSTANCE_NAME], data=self.data)
+                if not ccus:
+                    errors["base"] = "no_ccus"
+                else:
+                    # Route into the shared CCU-selection step so manual
+                    # setups get the same serial-keyed dedup and in-place
+                    # backend switch as discovered daemons.
+                    self._loom_token = self.data.get(CONF_LOOM_TOKEN)
+                    self._loom_enable_sub_devices = self.data[CONF_ADVANCED_CONFIG][CONF_ENABLE_SUB_DEVICES]
+                    self._loom_instance_name = user_input[CONF_INSTANCE_NAME]
+                    self._loom_discovery = {
+                        CONF_HOST: self.data[CONF_HOST],
+                        CONF_TLS: self.data[CONF_TLS],
+                        CONF_VERIFY_TLS: self.data[CONF_VERIFY_TLS],
+                        CONF_INSTANCE_NAME: user_input[CONF_INSTANCE_NAME],
+                    }
+                    if (port := self.data.get(CONF_LOOM_PORT)) is not None:
+                        self._loom_discovery[CONF_LOOM_PORT] = port
+                    self._loom_ccus = ccus
+                    return await self.async_step_loom_select_ccu()
         return self.async_show_form(
             step_id="loom",
             data_schema=get_loom_schema(data=self.data),
@@ -1182,6 +1253,7 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         }
         if user_input is not None:
             token = user_input.get(CONF_LOOM_TOKEN) or ""
+            self._loom_enable_sub_devices = user_input.get(CONF_ENABLE_SUB_DEVICES, DEFAULT_LOOM_ENABLE_SUB_DEVICES)
             try:
                 ccus = await _async_loom_list_ccus(
                     self.hass,
@@ -1281,6 +1353,7 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {
             CONF_NAME: self.data.get(CONF_INSTANCE_NAME, ""),
             CONF_HOST: self.data.get(CONF_HOST, ""),
+            CONF_BACKEND: _get_backend_title(backend=self.data.get(CONF_BACKEND)),
         }
 
         return await self.async_step_reauth_confirm()
@@ -1306,10 +1379,8 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
                     hass=self.hass, data=self.data, entry_id=entry.entry_id
                 )
                 # Validation successful - update entry and finish
-                return self.async_update_reload_and_abort(
-                    entry,
-                    data=self.data,
-                    reason="reauth_successful",
+                return self._async_update_reload_and_abort_entry(
+                    entry=entry, data=self.data, reason="reauth_successful"
                 )
             except AuthFailure:
                 errors["base"] = "invalid_auth"
@@ -1349,6 +1420,7 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {
             CONF_NAME: entry.data.get(CONF_INSTANCE_NAME, ""),
             CONF_HOST: entry.data.get(CONF_HOST, ""),
+            CONF_BACKEND: _get_backend_title(backend=entry.data.get(CONF_BACKEND)),
         }
 
         errors: dict[str, str] = {}
@@ -1504,7 +1576,11 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         self.data = {CONF_INSTANCE_NAME: instance_name, CONF_HOST: host}
-        self.context["title_placeholders"] = {CONF_NAME: instance_name, CONF_HOST: host}
+        self.context["title_placeholders"] = {
+            CONF_NAME: instance_name,
+            CONF_HOST: host,
+            CONF_BACKEND: _get_backend_title(backend=BACKEND_CCU),
+        }
         return await self.async_step_user()
 
     async def async_step_user(self, user_input: ConfigType | None = None) -> ConfigFlowResult:
@@ -1545,7 +1621,11 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_LOOM_BASE_PATH: base_path,
             CONF_INSTANCE_NAME: instance,
         }
-        self.context["title_placeholders"] = {CONF_NAME: instance, CONF_HOST: host}
+        self.context["title_placeholders"] = {
+            CONF_NAME: instance,
+            CONF_HOST: host,
+            CONF_BACKEND: _get_backend_title(backend=BACKEND_LOOM),
+        }
         return await self.async_step_loom_token()
 
     def _apply_detected_interfaces(self) -> None:
@@ -1568,31 +1648,59 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         self.data[CONF_INTERFACE] = interfaces
 
     async def _async_create_loom_entry(self, ccu: dict[str, Any]) -> ConfigFlowResult:
-        """Create the config entry for the chosen CCU on a discovered daemon."""
+        """Create the config entry for the chosen CCU on a discovered daemon.
+
+        A serial already configured on the direct-CCU backend is switched
+        to the loom backend in place: the existing entry keeps its
+        entry_id, instance name and advanced config (incl.
+        sub_devices_enabled), so entities and history survive the switch.
+        """
         disc = self._loom_discovery
         serial = ccu["serial"]
         # A concurrent CCU discovery (e.g. SSDP) may hold an in-progress flow
         # with this serial; we have already committed to the loom backend here,
-        # so do not abort our own flow. Creating the entry below auto-aborts the
-        # now-redundant discovery card.
-        await self.async_set_unique_id(serial, raise_on_progress=False)
-        self._abort_if_unique_id_configured(
-            error="already_configured",
-            description_placeholders={"serial": serial or "unknown"},
-        )
+        # so do not abort our own flow. Finishing the flow below auto-aborts
+        # the now-redundant discovery card.
+        existing_entry = await self.async_set_unique_id(serial, raise_on_progress=False)
+        instance_name = self._loom_instance_name or ccu["name"]
         data: ConfigType = {
             CONF_BACKEND: BACKEND_LOOM,
-            CONF_INSTANCE_NAME: ccu["name"],
+            CONF_INSTANCE_NAME: instance_name,
             CONF_HOST: disc[CONF_HOST],
             CONF_TLS: disc[CONF_TLS],
-            CONF_VERIFY_TLS: True,
-            # mDNS always advertises a port (validated in async_step_zeroconf).
-            CONF_LOOM_PORT: int(disc[CONF_LOOM_PORT]),
-            CONF_ADVANCED_CONFIG: {},
+            CONF_VERIFY_TLS: disc.get(CONF_VERIFY_TLS, True),
+            CONF_ADVANCED_CONFIG: {CONF_ENABLE_SUB_DEVICES: self._loom_enable_sub_devices},
         }
+        # mDNS always advertises a port; the manual form may leave it blank
+        # (the loom client applies its TLS-dependent default at runtime).
+        if (port := disc.get(CONF_LOOM_PORT)) is not None:
+            data[CONF_LOOM_PORT] = int(port)
         if self._loom_token:
             data[CONF_LOOM_TOKEN] = self._loom_token
-        return self.async_create_entry(title=ccu["name"], data=data)
+        if existing_entry is not None:
+            if existing_entry.data.get(CONF_BACKEND, BACKEND_CCU) == BACKEND_LOOM:
+                return self.async_abort(
+                    reason="already_configured",
+                    description_placeholders={"serial": serial or "unknown"},
+                )
+            # In-place backend switch CCU -> loom. The stale CCU connection
+            # keys (credentials, interfaces) stay in the entry so a switch
+            # back is lossless; the reload re-keys the entities via the
+            # unique_id migration in __init__.
+            switched = dict(existing_entry.data)
+            switched.update(data)
+            # The instance name keys entity naming - keep it stable.
+            switched[CONF_INSTANCE_NAME] = existing_entry.data[CONF_INSTANCE_NAME]
+            # Migrate the advanced config; an explicit sub_devices_enabled
+            # choice on the entry wins over the form value.
+            switched[CONF_ADVANCED_CONFIG] = {
+                CONF_ENABLE_SUB_DEVICES: self._loom_enable_sub_devices,
+                **existing_entry.data.get(CONF_ADVANCED_CONFIG, {}),
+            }
+            return self._async_update_reload_and_abort_entry(
+                entry=existing_entry, data=switched, reason="backend_switched"
+            )
+        return self.async_create_entry(title=instance_name, data=data)
 
     async def _async_run_detection(self) -> None:
         """Run backend detection as background task."""
@@ -1645,6 +1753,23 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
             self._detection_error = "detection_failed"
             self._detection_error_detail = self.data[CONF_HOST]
 
+    @callback
+    def _async_update_reload_and_abort_entry(
+        self, *, entry: ConfigEntry, data: ConfigType, reason: str
+    ) -> ConfigFlowResult:
+        """Update the entry, trigger exactly one reload and abort the flow.
+
+        Replaces :meth:`ConfigFlow.async_update_reload_and_abort` for this
+        integration: a loaded entry already reloads through the registered
+        update listener when its data changes, so scheduling a reload as
+        well would reload twice (deprecated with HA 2026.12). Only unloaded
+        entries and unchanged data need the explicit reload.
+        """
+        changed = self.hass.config_entries.async_update_entry(entry, data=data)
+        if not (changed and entry.state is ConfigEntryState.LOADED):
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
+        return self.async_abort(reason=reason)
+
     def _get_undetected_interfaces(self) -> list[Interface]:
         """Return list of enabled interfaces that were not detected on the CCU."""
         if not self._detection_result:
@@ -1656,7 +1781,13 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
         return sorted(configured - detected, key=lambda i: i.value)
 
     async def _validate_and_finish_config_flow(self) -> ConfigFlowResult:
-        """Validate and finish the config flow."""
+        """Validate and finish the config flow.
+
+        A serial already configured on the loom backend is switched to the
+        direct-CCU backend in place: the existing entry keeps its entry_id,
+        instance name and advanced config (incl. sub_devices_enabled), so
+        entities and history survive the switch.
+        """
 
         errors = {}
         description_placeholders = {}
@@ -1666,12 +1797,31 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
                 hass=self.hass, data=self.data, entry_id="validate"
             )
             if system_information is not None:
-                await self.async_set_unique_id(system_information.serial)
-                self._abort_if_unique_id_configured(
-                    updates={},
-                    error="already_configured",
-                    description_placeholders={"serial": system_information.serial or "unknown"},
-                )
+                serial = system_information.serial
+                existing_entry = await self.async_set_unique_id(serial)
+                if existing_entry is not None:
+                    if existing_entry.data.get(CONF_BACKEND, BACKEND_CCU) != BACKEND_LOOM:
+                        return self.async_abort(
+                            reason="already_configured",
+                            description_placeholders={"serial": serial or "unknown"},
+                        )
+                    # In-place backend switch loom -> CCU. The stale loom
+                    # connection keys (daemon port, token) stay in the entry
+                    # so a switch back is lossless; the reload re-keys the
+                    # entities via the unique_id migration in __init__.
+                    switched = dict(existing_entry.data)
+                    switched.update(self.data)
+                    # The instance name keys entity naming - keep it stable.
+                    switched[CONF_INSTANCE_NAME] = existing_entry.data[CONF_INSTANCE_NAME]
+                    # Migrate the advanced config; settings collected in this
+                    # flow's advanced step win over the entry's values.
+                    switched[CONF_ADVANCED_CONFIG] = {
+                        **existing_entry.data.get(CONF_ADVANCED_CONFIG, {}),
+                        **self.data.get(CONF_ADVANCED_CONFIG, {}),
+                    }
+                    return self._async_update_reload_and_abort_entry(
+                        entry=existing_entry, data=switched, reason="backend_switched"
+                    )
         except AuthFailure:
             errors["base"] = "invalid_auth"
             description_placeholders["invalid_items"] = self.data[CONF_HOST]

--- a/custom_components/homematicip_local/const.py
+++ b/custom_components/homematicip_local/const.py
@@ -24,6 +24,8 @@ DEFAULT_ENABLE_MQTT: Final = False
 DEFAULT_MQTT_PREFIX: Final = ""
 DEFAULT_DISABLE_CONFIG_PANEL: Final = False
 DEFAULT_ENABLE_SUB_DEVICES: Final = False
+# The loom backend defaults sub-device entities to enabled in its setup flow.
+DEFAULT_LOOM_ENABLE_SUB_DEVICES: Final = True
 DEFAULT_COMMAND_RETRY_MAX_ATTEMPTS: Final = 3
 DEFAULT_COMMAND_THROTTLE_INTERVAL: Final = 0.1
 

--- a/custom_components/homematicip_local/strings.json
+++ b/custom_components/homematicip_local/strings.json
@@ -2,6 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Entry with the serial {serial} is already configured", 
+            "backend_switched": "Backend switched for the already configured CCU. The existing entry keeps its settings, entities and history.", 
             "invalid_discovery_info": "Incomplete discovery information.", 
             "loom_not_enabled": "The openccu-loom backend is not enabled.", 
             "reauth_failed": "Could not find the configuration entry to reauthenticate", 
@@ -18,7 +19,7 @@
             "no_ccus": "The daemon reports no CCUs.", 
             "unknown": "An unexpected error occurred. Please check the Home Assistant logs for more details."
         }, 
-        "flow_title": "{name}/{host}", 
+        "flow_title": "{name}/{host} ({backend})", 
         "progress": {
             "detect_backend": "Detecting backend type and available interfaces..."
         }, 
@@ -122,8 +123,12 @@
                     "instance_name": "Integration instance name", 
                     "loom_port": "Daemon port (blank = 8443 TLS / 8080 plain)", 
                     "loom_token": "API bearer token", 
+                    "sub_devices_enabled": "Create sub-device entities", 
                     "tls": "Use TLS (HTTPS/WSS)", 
                     "verify_tls": "Verify TLS certificate"
+                }, 
+                "data_description": {
+                    "sub_devices_enabled": "Splits devices with multiple channel groups into a main device with sub-devices. Entities are assigned to their corresponding sub-device based on channel group."
                 }, 
                 "description": "Connect to an openccu-loom daemon. The daemon owns the CCU connection, interfaces and callbacks.", 
                 "title": "OpenCCU-Loom daemon"
@@ -144,7 +149,11 @@
             }, 
             "loom_token": {
                 "data": {
-                    "loom_token": "API bearer token"
+                    "loom_token": "API bearer token", 
+                    "sub_devices_enabled": "Create sub-device entities"
+                }, 
+                "data_description": {
+                    "sub_devices_enabled": "Splits devices with multiple channel groups into a main device with sub-devices. Entities are assigned to their corresponding sub-device based on channel group."
                 }, 
                 "description": "Enter the API bearer token for the discovered daemon {name} at {host}.", 
                 "title": "OpenCCU-Loom daemon token"

--- a/custom_components/homematicip_local/translations/de.json
+++ b/custom_components/homematicip_local/translations/de.json
@@ -2,6 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Eintrag mit der Seriennummer {serial} ist bereits konfiguriert", 
+            "backend_switched": "Backend für die bereits konfigurierte CCU gewechselt. Der bestehende Eintrag behält Einstellungen, Entitäten und Verlauf.", 
             "invalid_discovery_info": "Unvollständige Discovery-Informationen.", 
             "loom_not_enabled": "Das openccu-loom-Backend ist nicht aktiviert.", 
             "reauth_failed": "Der Konfigurationseintrag zur erneuten Authentifizierung konnte nicht gefunden werden", 
@@ -18,7 +19,7 @@
             "no_ccus": "Der Daemon meldet keine CCUs.", 
             "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte überprüfe die Home Assistant Protokolle für weitere Details."
         }, 
-        "flow_title": "{name}/{host}", 
+        "flow_title": "{name}/{host} ({backend})", 
         "progress": {
             "detect_backend": "Backend-Typ und verfügbare Schnittstellen werden erkannt..."
         }, 
@@ -122,8 +123,12 @@
                     "instance_name": "Name der Integrations-Instanz", 
                     "loom_port": "Daemon-Port (leer = 8443 TLS / 8080 unverschlüsselt)", 
                     "loom_token": "API-Bearer-Token", 
+                    "sub_devices_enabled": "Untergeräte-Entitäten erstellen", 
                     "tls": "TLS verwenden (HTTPS/WSS)", 
                     "verify_tls": "TLS-Zertifikat prüfen"
+                }, 
+                "data_description": {
+                    "sub_devices_enabled": "Teilt Geräte mit mehreren Kanalgruppen in ein Hauptgerät mit Untergeräten auf. Entitäten werden basierend auf ihrer Kanalgruppe dem entsprechenden Untergerät zugeordnet."
                 }, 
                 "description": "Mit einem openccu-loom-Daemon verbinden. Der Daemon verwaltet CCU-Verbindung, Interfaces und Callbacks.", 
                 "title": "OpenCCU-Loom-Daemon"
@@ -144,7 +149,11 @@
             }, 
             "loom_token": {
                 "data": {
-                    "loom_token": "API-Bearer-Token"
+                    "loom_token": "API-Bearer-Token", 
+                    "sub_devices_enabled": "Untergeräte-Entitäten erstellen"
+                }, 
+                "data_description": {
+                    "sub_devices_enabled": "Teilt Geräte mit mehreren Kanalgruppen in ein Hauptgerät mit Untergeräten auf. Entitäten werden basierend auf ihrer Kanalgruppe dem entsprechenden Untergerät zugeordnet."
                 }, 
                 "description": "Gib den API-Bearer-Token für den gefundenen Daemon „{name}\" unter {host} ein.", 
                 "title": "OpenCCU-Loom-Daemon-Token"

--- a/custom_components/homematicip_local/translations/en.json
+++ b/custom_components/homematicip_local/translations/en.json
@@ -7,7 +7,8 @@
       "reconfigure_failed": "Could not find the configuration entry to reconfigure",
       "reconfigure_successful": "Connection settings updated successfully",
       "loom_not_enabled": "The openccu-loom backend is not enabled.",
-      "invalid_discovery_info": "Incomplete discovery information."
+      "invalid_discovery_info": "Incomplete discovery information.",
+      "backend_switched": "Backend switched for the already configured CCU. The existing entry keeps its settings, entities and history."
     },
     "error": {
       "cannot_connect": "Cannot connect to CCU [{invalid_items}]. Please verify: 1) The hostname/IP address is correct, 2) The CCU is powered on and reachable, 3) No firewall is blocking the connection.",
@@ -18,7 +19,7 @@
       "unknown": "An unexpected error occurred. Please check the Home Assistant logs for more details.",
       "no_ccus": "The daemon reports no CCUs."
     },
-    "flow_title": "{name}/{host}",
+    "flow_title": "{name}/{host} ({backend})",
     "progress": {
       "detect_backend": "Detecting backend type and available interfaces..."
     },
@@ -123,10 +124,14 @@
           "loom_port": "Daemon port (blank = 8443 TLS / 8080 plain)",
           "loom_token": "API bearer token",
           "tls": "Use TLS (HTTPS/WSS)",
-          "verify_tls": "Verify TLS certificate"
+          "verify_tls": "Verify TLS certificate",
+          "sub_devices_enabled": "Create sub-device entities"
         },
         "description": "Connect to an openccu-loom daemon. The daemon owns the CCU connection, interfaces and callbacks.",
-        "title": "OpenCCU-Loom daemon"
+        "title": "OpenCCU-Loom daemon",
+        "data_description": {
+          "sub_devices_enabled": "Splits devices with multiple channel groups into a main device with sub-devices. Entities are assigned to their corresponding sub-device based on channel group."
+        }
       },
       "port_config": {
         "data": {
@@ -222,7 +227,11 @@
         "title": "OpenCCU-Loom daemon token",
         "description": "Enter the API bearer token for the discovered daemon {name} at {host}.",
         "data": {
-          "loom_token": "API bearer token"
+          "loom_token": "API bearer token",
+          "sub_devices_enabled": "Create sub-device entities"
+        },
+        "data_description": {
+          "sub_devices_enabled": "Splits devices with multiple channel groups into a main device with sub-devices. Entities are assigned to their corresponding sub-device based on channel group."
         }
       },
       "loom_select_ccu": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -39,6 +39,7 @@ from custom_components.homematicip_local.config_flow import (
     CONF_VIRTUAL_DEVICES_PORT,
     IF_VIRTUAL_DEVICES_PATH,
     LOOM_MANUAL_DAEMON,
+    DomainConfigFlow,
     InvalidConfig,
     _async_loom_list_ccus,
     _async_validate_config_and_get_system_information,
@@ -56,6 +57,7 @@ from custom_components.homematicip_local.config_flow import (
     get_loom_options_schema,
 )
 from custom_components.homematicip_local.const import (
+    BACKEND_CCU,
     BACKEND_LOOM,
     CONF_ADVANCED_CONFIG as CONST_ADVANCED_CONFIG,
     CONF_BACKEND,
@@ -1020,7 +1022,11 @@ class TestDiscoveryFlow:
         assert len(flows) == 1
         assert flows[0].get("context", {}) == {
             "source": "ssdp",
-            "title_placeholders": {"host": const.HOST, "name": const.INSTANCE_NAME},
+            "title_placeholders": {
+                "host": const.HOST,
+                "name": const.INSTANCE_NAME,
+                "backend": "aiohomematic",
+            },
             "unique_id": const.CONFIG_ENTRY_UNIQUE_ID,
         }
 
@@ -3461,8 +3467,12 @@ class TestLoomZeroconfDiscovery:
     """mDNS (zeroconf) discovery of an openccu-loom daemon."""
 
     async def test_already_configured_aborts_with_serial(self, hass: HomeAssistant) -> None:
-        """A CCU whose serial is already configured aborts and renders the serial placeholder."""
-        existing = MockConfigEntry(domain=HMIP_DOMAIN, unique_id="ABC123", data={CONF_HOST: "ccu.local"})
+        """A CCU already configured on the loom backend aborts and renders the serial placeholder."""
+        existing = MockConfigEntry(
+            domain=HMIP_DOMAIN,
+            unique_id="ABC123",
+            data={CONF_BACKEND: BACKEND_LOOM, CONF_HOST: "daemon.local"},
+        )
         existing.add_to_hass(hass)
         ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
         with (
@@ -3484,6 +3494,46 @@ class TestLoomZeroconfDiscovery:
             result = await hass.config_entries.flow.async_configure(init["flow_id"], {CONF_LOOM_TOKEN: "x"})
         assert result["type"] == FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
+
+    async def test_ccu_entry_switched_to_loom_in_place(self, hass: HomeAssistant) -> None:
+        """A serial configured on the CCU backend is switched to loom in place."""
+        existing = MockConfigEntry(
+            domain=HMIP_DOMAIN,
+            unique_id="ABC123",
+            title=const.INSTANCE_NAME,
+            version=DomainConfigFlow.VERSION,
+            data={
+                CONF_INSTANCE_NAME: const.INSTANCE_NAME,
+                CONF_HOST: "ccu.local",
+                CONF_USERNAME: const.USERNAME,
+                CONF_PASSWORD: const.PASSWORD,
+                CONST_ADVANCED_CONFIG: {CONF_ENABLE_SUB_DEVICES: False, CONF_ENABLE_MQTT: True},
+            },
+        )
+        existing.add_to_hass(hass)
+        ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
+        with (
+            patch(_LOOM_ENABLED, True),
+            patch(_LOOM_LIST, return_value=ccus),
+            patch("custom_components.homematicip_local.async_setup_entry", return_value=True),
+        ):
+            init = await self._init_zeroconf(hass, _loom_zeroconf_info())
+            result = await hass.config_entries.flow.async_configure(init["flow_id"], {CONF_LOOM_TOKEN: "tok"})
+            await hass.async_block_till_done()
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "backend_switched"
+        data = existing.data
+        assert data[CONF_BACKEND] == BACKEND_LOOM
+        assert data[CONF_HOST] == "192.168.1.50"
+        assert data[CONF_LOOM_PORT] == 8080
+        assert data[CONF_LOOM_TOKEN] == "tok"
+        # Instance name and CCU credentials survive for a lossless switch back.
+        assert data[CONF_INSTANCE_NAME] == const.INSTANCE_NAME
+        assert data[CONF_USERNAME] == const.USERNAME
+        assert data[CONF_PASSWORD] == const.PASSWORD
+        # The entry's explicit advanced config wins over the form default.
+        assert data[CONST_ADVANCED_CONFIG][CONF_ENABLE_SUB_DEVICES] is False
+        assert data[CONST_ADVANCED_CONFIG][CONF_ENABLE_MQTT] is True
 
     async def test_disabled_aborts(self, hass: HomeAssistant) -> None:
         with patch(_LOOM_ENABLED, False):
@@ -3606,11 +3656,150 @@ class TestLoomZeroconfDiscovery:
         assert entry.data[CONF_HOST] == "192.168.1.50"
         assert entry.data[CONF_LOOM_PORT] == 8080
         assert entry.data[CONF_LOOM_TOKEN] == "tok"
+        # Sub-device entities default to enabled on the loom backend.
+        assert entry.data[CONST_ADVANCED_CONFIG] == {CONF_ENABLE_SUB_DEVICES: True}
+
+    async def test_switch_of_loaded_entry_skips_schedule_reload(self, hass: HomeAssistant) -> None:
+        """A loaded entry reloads via its update listener - no extra schedule."""
+        existing = MockConfigEntry(
+            domain=HMIP_DOMAIN,
+            unique_id="ABC123",
+            version=DomainConfigFlow.VERSION,
+            data={CONF_INSTANCE_NAME: const.INSTANCE_NAME, CONF_HOST: "ccu.local"},
+        )
+        existing.add_to_hass(hass)
+        existing.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+        ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
+        with (
+            patch(_LOOM_ENABLED, True),
+            patch(_LOOM_LIST, return_value=ccus),
+            patch.object(hass.config_entries, "async_schedule_reload") as schedule_reload,
+        ):
+            init = await self._init_zeroconf(hass, _loom_zeroconf_info())
+            result = await hass.config_entries.flow.async_configure(init["flow_id"], {CONF_LOOM_TOKEN: "tok"})
+            await hass.async_block_till_done()
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "backend_switched"
+        schedule_reload.assert_not_called()
+
+    async def test_token_step_can_disable_sub_devices(self, hass: HomeAssistant) -> None:
+        """Unchecking the sub-device toggle in the token step is persisted."""
+        ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
+        with (
+            patch(_LOOM_ENABLED, True),
+            patch(_LOOM_LIST, return_value=ccus),
+            patch("custom_components.homematicip_local.async_setup_entry", return_value=True),
+        ):
+            init = await self._init_zeroconf(hass, _loom_zeroconf_info())
+            done = await hass.config_entries.flow.async_configure(
+                init["flow_id"], {CONF_LOOM_TOKEN: "tok", CONF_ENABLE_SUB_DEVICES: False}
+            )
+            await hass.async_block_till_done()
+        assert done["type"] == FlowResultType.CREATE_ENTRY
+        assert done["result"].data[CONST_ADVANCED_CONFIG] == {CONF_ENABLE_SUB_DEVICES: False}
 
     async def _init_zeroconf(self, hass: HomeAssistant, info: ZeroconfServiceInfo) -> dict:
         return await hass.config_entries.flow.async_init(
             HMIP_DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=info
         )
+
+
+class TestBackendSwitchToCcu:
+    """The central flow switches an existing loom entry back to the CCU backend in place."""
+
+    async def test_central_flow_same_backend_still_aborts(self, hass: HomeAssistant) -> None:
+        """A serial already configured on the CCU backend keeps aborting with already_configured."""
+        existing = MockConfigEntry(
+            domain=HMIP_DOMAIN,
+            unique_id=const.SERIAL,
+            version=DomainConfigFlow.VERSION,
+            data={CONF_INSTANCE_NAME: const.INSTANCE_NAME, CONF_HOST: const.HOST},
+        )
+        existing.add_to_hass(hass)
+        result3 = await self._run_central_flow(hass)
+        assert result3["type"] == FlowResultType.ABORT
+        assert result3["reason"] == "already_configured"
+        assert result3["description_placeholders"] == {"serial": const.SERIAL}
+
+    async def test_loom_entry_switched_to_ccu_in_place(self, hass: HomeAssistant) -> None:
+        existing = MockConfigEntry(
+            domain=HMIP_DOMAIN,
+            unique_id=const.SERIAL,
+            title=const.INSTANCE_NAME,
+            version=DomainConfigFlow.VERSION,
+            data={
+                CONF_BACKEND: BACKEND_LOOM,
+                CONF_INSTANCE_NAME: const.INSTANCE_NAME,
+                CONF_HOST: "daemon.local",
+                CONF_LOOM_PORT: 8443,
+                CONF_LOOM_TOKEN: "tok",
+                CONST_ADVANCED_CONFIG: {CONF_ENABLE_SUB_DEVICES: True},
+            },
+        )
+        existing.add_to_hass(hass)
+        result3 = await self._run_central_flow(hass)
+        assert result3["type"] == FlowResultType.ABORT
+        assert result3["reason"] == "backend_switched"
+        data = existing.data
+        assert data[CONF_BACKEND] == BACKEND_CCU
+        assert data[CONF_HOST] == const.HOST
+        assert data[CONF_USERNAME] == const.USERNAME
+        assert data[CONF_PASSWORD] == const.PASSWORD
+        # The instance name keys entity naming and stays stable on a switch.
+        assert data[CONF_INSTANCE_NAME] == const.INSTANCE_NAME
+        # Loom connection keys survive for a lossless switch back.
+        assert data[CONF_LOOM_PORT] == 8443
+        assert data[CONF_LOOM_TOKEN] == "tok"
+        # The entry's advanced config (incl. sub_devices_enabled) is migrated.
+        assert data[CONST_ADVANCED_CONFIG][CONF_ENABLE_SUB_DEVICES] is True
+
+    async def _run_central_flow(self, hass: HomeAssistant) -> dict:
+        """Drive a fresh central flow (serial const.SERIAL) up to its final result."""
+        with (
+            patch(
+                "custom_components.homematicip_local.config_flow._async_detect_backend",
+                new_callable=AsyncMock,
+                return_value=_get_default_detection_result(),
+            ),
+            patch(
+                "custom_components.homematicip_local.config_flow._async_validate_config_and_get_system_information",
+                new_callable=AsyncMock,
+                return_value=SystemInformation(
+                    available_interfaces=[],
+                    auth_enabled=False,
+                    https_redirect_enabled=False,
+                    serial=const.SERIAL,
+                ),
+            ),
+            patch("custom_components.homematicip_local.async_setup_entry", return_value=True),
+        ):
+            result = await _async_init_user_flow_at_central(hass)
+            result2 = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_INSTANCE_NAME: "Fresh Name",
+                    CONF_HOST: const.HOST,
+                    CONF_USERNAME: const.USERNAME,
+                    CONF_PASSWORD: const.PASSWORD,
+                },
+            )
+            await hass.async_block_till_done()
+            while result2["type"] in (FlowResultType.SHOW_PROGRESS, FlowResultType.SHOW_PROGRESS_DONE):
+                await hass.async_block_till_done()
+                result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
+                await hass.async_block_till_done()
+            assert result2["type"] == FlowResultType.FORM
+            assert result2["step_id"] == "interface"
+            result3 = await hass.config_entries.flow.async_configure(
+                result["flow_id"], {CONF_TLS: False, CONF_VERIFY_TLS: False}
+            )
+            await hass.async_block_till_done()
+            if result3["type"] == FlowResultType.MENU:
+                result3 = await hass.config_entries.flow.async_configure(
+                    result["flow_id"], {"next_step_id": "finish_setup"}
+                )
+                await hass.async_block_till_done()
+            return result3
 
 
 class TestAsyncLoomListCcus:
@@ -3660,31 +3849,89 @@ def _loom_daemon(host: str, port: int, instance: str) -> dict:
 class TestLoomActiveBrowse:
     """User-initiated loom flow actively browses for daemons via mDNS."""
 
+    async def test_manual_entry_auth_failure(self, hass: HomeAssistant) -> None:
+        """A rejected token surfaces invalid_auth on the manual form."""
+        result = await self._submit_manual(hass, loom_list=AuthFailure("bad token"))
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "invalid_auth"}
+
+    async def test_manual_entry_cannot_connect(self, hass: HomeAssistant) -> None:
+        """An unreachable daemon surfaces cannot_connect on the manual form."""
+        result = await self._submit_manual(hass, loom_list=NoConnectionException("unreachable"))
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
     async def test_manual_entry_creates_entry(self, hass: HomeAssistant) -> None:
-        with (
-            patch(_LOOM_ENABLED, True),
-            patch(_BROWSE, return_value=[]),
-            patch("custom_components.homematicip_local.config_flow.ControlConfig") as control_config,
-            patch("custom_components.homematicip_local.async_setup_entry", return_value=True),
-        ):
-            control_config.return_value.check_config = AsyncMock(return_value=None)
-            form = await self._init_loom(hass)
-            assert form["step_id"] == "loom"
-            done = await hass.config_entries.flow.async_configure(
-                form["flow_id"],
-                {
-                    CONF_INSTANCE_NAME: "Manual Loom",
-                    CONF_HOST: "daemon.local",
-                    CONF_LOOM_PORT: 8080,
-                    CONF_TLS: False,
-                    CONF_VERIFY_TLS: False,
-                    CONF_LOOM_TOKEN: "tok",
-                },
-            )
-            await hass.async_block_till_done()
+        ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
+        done = await self._submit_manual(hass, loom_list=ccus)
         assert done["type"] == FlowResultType.CREATE_ENTRY
         assert done["title"] == "Manual Loom"
-        assert done["result"].data[CONF_HOST] == "daemon.local"
+        entry = done["result"]
+        # The manual path is serial-keyed via the shared CCU-selection step.
+        assert entry.unique_id == "ABC123"
+        assert entry.data[CONF_INSTANCE_NAME] == "Manual Loom"
+        assert entry.data[CONF_HOST] == "daemon.local"
+        assert entry.data[CONF_LOOM_PORT] == 8080
+        assert entry.data[CONF_LOOM_TOKEN] == "tok"
+        assert entry.data[CONF_VERIFY_TLS] is False
+        # Sub-device entities default to enabled on the loom backend.
+        assert entry.data[CONST_ADVANCED_CONFIG] == {CONF_ENABLE_SUB_DEVICES: True}
+
+    async def test_manual_entry_invalid_config(self, hass: HomeAssistant) -> None:
+        """A failing config check surfaces invalid_config on the manual form."""
+        result = await self._submit_manual(hass, loom_list=[], check_config=InvalidConfig("bad host"))
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "invalid_config"}
+
+    async def test_manual_entry_no_ccus(self, hass: HomeAssistant) -> None:
+        """A daemon without CCUs surfaces no_ccus on the manual form."""
+        result = await self._submit_manual(hass, loom_list=[])
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "no_ccus"}
+
+    async def test_manual_entry_switches_existing_ccu_entry(self, hass: HomeAssistant) -> None:
+        """The manual path switches an existing CCU entry to loom in place."""
+        existing = MockConfigEntry(
+            domain=HMIP_DOMAIN,
+            unique_id="ABC123",
+            title=const.INSTANCE_NAME,
+            version=DomainConfigFlow.VERSION,
+            data={
+                CONF_INSTANCE_NAME: const.INSTANCE_NAME,
+                CONF_HOST: "ccu.local",
+                CONF_USERNAME: const.USERNAME,
+                CONF_PASSWORD: const.PASSWORD,
+                CONST_ADVANCED_CONFIG: {CONF_ENABLE_SUB_DEVICES: False},
+            },
+        )
+        existing.add_to_hass(hass)
+        ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
+        result = await self._submit_manual(hass, loom_list=ccus)
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "backend_switched"
+        data = existing.data
+        assert data[CONF_BACKEND] == BACKEND_LOOM
+        assert data[CONF_HOST] == "daemon.local"
+        # The entry keeps its instance name and explicit sub_devices choice.
+        assert data[CONF_INSTANCE_NAME] == const.INSTANCE_NAME
+        assert data[CONST_ADVANCED_CONFIG][CONF_ENABLE_SUB_DEVICES] is False
+
+    async def test_manual_entry_without_port_omits_port(self, hass: HomeAssistant) -> None:
+        """A blank daemon port stays absent from the entry (runtime defaults apply)."""
+        ccus = [{"name": "Home", "serial": "ABC123", "host": "ccu.local", "model": "CCU3", "available": True}]
+        done = await self._submit_manual(
+            hass,
+            loom_list=ccus,
+            user_input={
+                CONF_INSTANCE_NAME: "Manual Loom",
+                CONF_HOST: "daemon.local",
+                CONF_TLS: False,
+                CONF_VERIFY_TLS: False,
+                CONF_LOOM_TOKEN: "tok",
+            },
+        )
+        assert done["type"] == FlowResultType.CREATE_ENTRY
+        assert CONF_LOOM_PORT not in done["result"].data
 
     async def test_multi_daemon_pick_then_token_then_entry(self, hass: HomeAssistant) -> None:
         daemons = [_loom_daemon("h1", 8080, "D1"), _loom_daemon("h2", 8081, "D2")]
@@ -3734,3 +3981,36 @@ class TestLoomActiveBrowse:
     async def _init_loom(self, hass: HomeAssistant) -> dict:
         result = await hass.config_entries.flow.async_init(HMIP_DOMAIN, context={"source": config_entries.SOURCE_USER})
         return await hass.config_entries.flow.async_configure(result["flow_id"], {"next_step_id": "loom"})
+
+    async def _submit_manual(
+        self,
+        hass: HomeAssistant,
+        *,
+        loom_list: Any,
+        check_config: Exception | None = None,
+        user_input: dict | None = None,
+    ) -> dict:
+        """Drive the manual loom form to its result with the given backend behavior."""
+        if user_input is None:
+            user_input = {
+                CONF_INSTANCE_NAME: "Manual Loom",
+                CONF_HOST: "daemon.local",
+                CONF_LOOM_PORT: 8080,
+                CONF_TLS: False,
+                CONF_VERIFY_TLS: False,
+                CONF_LOOM_TOKEN: "tok",
+            }
+        loom_kwargs = {"side_effect": loom_list} if isinstance(loom_list, Exception) else {"return_value": loom_list}
+        with (
+            patch(_LOOM_ENABLED, True),
+            patch(_BROWSE, return_value=[]),
+            patch(_LOOM_LIST, **loom_kwargs),
+            patch("custom_components.homematicip_local.config_flow.ControlConfig") as control_config,
+            patch("custom_components.homematicip_local.async_setup_entry", return_value=True),
+        ):
+            control_config.return_value.check_config = AsyncMock(side_effect=check_config)
+            form = await self._init_loom(hass)
+            assert form["step_id"] == "loom"
+            result = await hass.config_entries.flow.async_configure(form["flow_id"], user_input)
+            await hass.async_block_till_done()
+        return result


### PR DESCRIPTION
## What's Changed

### Backend visible in discovery
`flow_title` now carries a `{backend}` placeholder (`aiohomematic` for a CCU discovered via SSDP, `openccu-loom` for a daemon discovered via mDNS), so two discovery cards for the same CCU are distinguishable before clicking. Reauth and reconfigure flow titles carry the entry's backend the same way.

### In-place backend switch
Setting up a CCU whose serial is already configured on the *other* backend no longer aborts with `already_configured` — the existing entry switches backend in place (abort reason `backend_switched`) and reloads:

- entry_id, instance name and advanced config (incl. `sub_devices_enabled`) are preserved, so entities, history and customisations survive the CCU ⇄ loom round-trip (the unique_id migrations in `__init__.py` re-key the entities on reload)
- the previous backend's connection keys (CCU credentials / daemon port + token) stay in the entry, making a switch back lossless
- the same serial on the *same* backend still aborts with `already_configured`

### Sub-device toggle in the loom flow
The loom setup flow (manual form and discovered-daemon token step) offers **Create sub-device entities** directly, enabled by default (`DEFAULT_LOOM_ENABLE_SUB_DEVICES`). On a backend switch, an explicit choice stored on the existing entry wins over the form default.

### Serial-keyed manual loom setup
The manual loom form now validates the daemon connection, lists its CCUs and routes into the shared CCU-selection step. Manual entries are therefore serial-keyed like discovered ones — duplicate setups abort, the in-place backend switch applies, and auth/connection/no-CCU errors surface on the form. The user-chosen instance name is kept; a blank daemon port stays absent from the entry.

### Single-reload entry updates
New `_async_update_reload_and_abort_entry` (used by reauth and both switch paths) schedules a reload only when the registered update listener will not already do so (unloaded entry or unchanged data). Replaces `ConfigFlow.async_update_reload_and_abort`, whose extra reload schedule alongside an update listener double-reloaded and is deprecated with HA 2026.12.

## Tests

- Switch tests in both directions (`TestBackendSwitchToCcu`, zeroconf + manual CCU→loom), same-backend dedup, sub-device default/opt-out, manual-path error mapping (`invalid_auth` / `cannot_connect` / `invalid_config` / `no_ccus`), blank-port handling, and a no-double-reload test for loaded entries
- Full suite: 861 passed, 8 skipped; all prek hooks green