### PR TITLE
fix(config_flow): correct mDNS browse callback signature

### DIFF
--- a/custom_components/homematicip_local/config_flow.py
+++ b/custom_components/homematicip_local/config_flow.py
@@ -330,13 +330,16 @@ async def _async_browse_loom_daemons(hass: HomeAssistant) -> list[dict[str, Any]
     from zeroconf import ServiceStateChange  # noqa: PLC0415
     from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo  # noqa: PLC0415
 
-    from homeassistant.components import zeroconf  # noqa: PLC0415
+    from homeassistant.components import zeroconf as ha_zeroconf  # noqa: PLC0415
 
-    aiozc = await zeroconf.async_get_async_instance(hass)
+    aiozc = await ha_zeroconf.async_get_async_instance(hass)
     names: set[str] = set()
 
+    # zeroconf fires state changes with keyword arguments only
+    # (zeroconf=, service_type=, name=, state_change=), so the parameter
+    # names are part of the contract — renaming them breaks the callback.
     @callback
-    def _on_change(_zc: Any, _service_type: str, name: str, state_change: Any) -> None:
+    def _on_change(zeroconf: Any, service_type: str, name: str, state_change: Any) -> None:
         if state_change is not ServiceStateChange.Removed:
             names.add(name)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ipaddress import ip_address
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry, flush_store
@@ -39,8 +39,10 @@ from custom_components.homematicip_local.config_flow import (
     CONF_VIRTUAL_DEVICES_PORT,
     IF_VIRTUAL_DEVICES_PATH,
     LOOM_MANUAL_DAEMON,
+    ZEROCONF_TYPE,
     DomainConfigFlow,
     InvalidConfig,
+    _async_browse_loom_daemons,
     _async_loom_list_ccus,
     _async_validate_config_and_get_system_information,
     _get_ccu_data,
@@ -3912,6 +3914,64 @@ def _loom_daemon(host: str, port: int, instance: str) -> dict:
         CONF_LOOM_BASE_PATH: "/api/v1",
         CONF_INSTANCE_NAME: instance,
     }
+
+
+class TestLoomBrowseCallbackContract:
+    """The mDNS browse handler must honour zeroconf's callback contract.
+
+    ``zeroconf`` fires state changes with keyword arguments only
+    (``zeroconf=``, ``service_type=``, ``name=``, ``state_change=``), and it
+    fires them from the browser constructor when the shared cache already
+    holds matching services — which is the normal case in Home Assistant,
+    since the integration's manifest makes HA browse this service type. A
+    mismatched parameter name therefore raises synchronously inside the
+    config-flow step rather than being swallowed in a background task.
+    """
+
+    async def test_handler_accepts_keyword_call_from_constructor(self, hass: HomeAssistant) -> None:
+        """A cache-warm constructor callback must be accepted and collected."""
+        from zeroconf import ServiceStateChange
+
+        service_name = f"Daemon.{ZEROCONF_TYPE}"
+
+        class _CacheWarmBrowser:
+            """Stand-in for AsyncServiceBrowser that fires from its constructor."""
+
+            def __init__(self, _zc: Any, service_type: str, handlers: list[Any]) -> None:
+                for handler in handlers:
+                    handler(
+                        zeroconf=_zc,
+                        service_type=service_type,
+                        name=service_name,
+                        state_change=ServiceStateChange.Added,
+                    )
+
+            async def async_cancel(self) -> None:
+                return None
+
+        info = MagicMock()
+        info.async_request = AsyncMock(return_value=True)
+        info.parsed_addresses = MagicMock(return_value=["192.168.1.50"])
+        info.port = 8119
+        info.properties = {b"instance": b"Daemon", b"path": b"/api/v1", b"tls": b"0"}
+
+        with (
+            patch("zeroconf.asyncio.AsyncServiceBrowser", _CacheWarmBrowser),
+            patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
+            patch("homeassistant.components.zeroconf.async_get_async_instance", return_value=MagicMock()),
+            patch("custom_components.homematicip_local.config_flow.LOOM_BROWSE_SECONDS", 0),
+        ):
+            daemons = await _async_browse_loom_daemons(hass)
+
+        assert daemons == [
+            {
+                CONF_HOST: "192.168.1.50",
+                CONF_LOOM_PORT: 8119,
+                CONF_TLS: False,
+                CONF_LOOM_BASE_PATH: "/api/v1",
+                CONF_INSTANCE_NAME: "Daemon",
+            }
+        ]
 
 
 class TestLoomActiveBrowse:


### PR DESCRIPTION
## Symptom

Clicking **openccu-loom daemon** in the backend menu opens a page titled "Fehler" / "Error" instead of the daemon list.

## Cause

`zeroconf` fires service state changes with **keyword arguments only**:

```python
self._service_state_changed.fire(
    zeroconf=self.zc, service_type=type_, name=name, state_change=state_change
)
```

The handler's parameter names are therefore part of the contract. `_async_browse_loom_daemons` named them `_zc` / `_service_type`:

```python
def _on_change(_zc: Any, _service_type: str, name: str, state_change: Any) -> None:
```

which raises `TypeError: _on_change() got an unexpected keyword argument 'zeroconf'`.

The decisive detail is **when** it raises. zeroconf fires the handler from the `AsyncServiceBrowser` **constructor** whenever the shared cache already holds matching services. That is the normal case in Home Assistant: the integration's manifest declares `_openccu-loom._tcp.local.`, so HA browses the type itself and the cache is warm long before the flow attaches its own browser. The exception thus propagates synchronously out of the config-flow step — hence the error page rather than a silently empty result.

## Verification against real mDNS

Reproduced and fixed against two daemons announcing on the LAN:

| Scenario | Result |
|---|---|
| Cold cache, old signature | handler raises in the background listener, `names` stays empty |
| **Warm cache, old signature** | **`TypeError` raised synchronously from the constructor** ← the error page |
| Warm cache, new signature | no error; both daemons returned immediately from the cache |

## Fix

Handler parameters renamed to match zeroconf's contract, with a comment recording that the names are load-bearing. The HA zeroconf module import is aliased to `ha_zeroconf` so the `zeroconf` parameter does not shadow it.

## Regression test

`TestLoomBrowseCallbackContract` drives the handler through a browser stub that fires from its constructor with keyword arguments, mirroring the warm-cache path. Confirmed to fail with the old signature (`TypeError`) and pass with the new one — I reverted the fix temporarily to check this rather than assuming it.

## Scope

The bug predates the discovery gate but was unreachable while `LOOM_BACKEND_SELECTABLE` kept the loom path off; #1227 exposed it. The active browse carries `# pragma: no cover - live mDNS`, which is why it was never exercised.

## Testing

- `make test-ci` → 867 passed, 8 skipped
- `make prek` → all hooks pass
