### PR TITLE
fix(blueprints): stop suggesting error parameters that never arrive

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The complete documentation is available at **[sukramj.github.io/aiohomematic](ht
 |-------|------|
 | **Home Assistant Integration** | [User Guide](https://sukramj.github.io/aiohomematic/user/homeassistant_integration/) |
 | **Actions Reference** | [Actions](https://sukramj.github.io/aiohomematic/user/features/homeassistant_actions/) |
+| **Events Reference** | [Events](https://sukramj.github.io/aiohomematic/user/features/homeassistant_events/) |
 | **Troubleshooting** | [Troubleshooting Guide](https://sukramj.github.io/aiohomematic/user/troubleshooting/homeassistant_troubleshooting/) |
 | **Week Profiles** | [Week Profiles](https://sukramj.github.io/aiohomematic/user/features/week_profile/) |
 | **Naming Conventions** | [Naming](https://sukramj.github.io/aiohomematic/user/advanced/homeassistant_naming/) |
@@ -132,6 +133,12 @@ Ready-to-use automation blueprints are available in the [blueprints/automation](
 - Error event handlers
 
 Copy the desired blueprint files to your `config/blueprints/automation` directory.
+
+Blueprints that react to devices are driven by the integration's events — see the
+[Events Reference](https://sukramj.github.io/aiohomematic/user/features/homeassistant_events/)
+for which parameters trigger which event. Note that CCU service messages (`CONFIG_PENDING`,
+`UPDATE_PENDING`, …) are not events; they are available through the
+`sensor.<instance>_hub_service_messages` sensor.
 
 Community blueprints are welcome via pull request in [blueprints/community](blueprints/community).
 

--- a/blueprints/automation/homematicip_local_show_device_error.yaml
+++ b/blueprints/automation/homematicip_local_show_device_error.yaml
@@ -6,15 +6,19 @@ blueprint:
     Optionally restrict the notifications to specific devices and/or ignore selected
     error parameters to reduce noise.
 
-    Note: Some errors are expected and resolve on their own. For example, after
-    deleting a direct link (Direktverknüpfung) in the CCU/OCCU, the change is sent
-    to the device via a configuration transfer; until that completes, CONFIG_PENDING
-    stays true and the link still lives in the device. For battery/RF devices the
-    transfer only runs on the next radio contact - press a button on the device so
-    the CCU can deliver the pending configuration, then the notification clears
-    automatically. No factory reset is required.
+    Scope: The homematic.device_error event only carries device parameters whose name
+    starts with ERROR or SENSOR_ERROR - for example ERROR_OVERHEAT, ERROR_OVERLOAD,
+    ERROR_JAMMED, ERROR_NON_FLAT_POSITIONING or SENSOR_ERROR. ERROR_CODE is excluded
+    by the integration because it is a raw numeric code without a stable meaning.
 
-    v2026-06-24
+    Not covered: CCU service messages such as CONFIG_PENDING, UPDATE_PENDING,
+    STICKY_UNREACH, LOW_BAT or SABOTAGE never arrive as a device_error event. Use the
+    hub sensor sensor.<instance>_hub_service_messages for those - its state is the
+    number of active service messages and its attributes message_1, message_2, ...
+    list them individually. Device reachability has its own event,
+    homematic.device_availability.
+
+    v2026-08-02
   domain: automation
   homeassistant:
     min_version: "2026.3.0"
@@ -31,7 +35,7 @@ blueprint:
     ignored_parameters:
       name: Ignored error parameters (optional)
       description:
-        Comma-separated list of error parameter names to ignore (e.g. CONFIG_PENDING, STICKY_UNREACH).
+        Comma-separated list of error parameter names to ignore (e.g. ERROR_OVERHEAT, SENSOR_ERROR).
         Case-insensitive. Leave empty to show all error parameters.
       default: ""
       selector:

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,14 @@
 - Event entities now carry the full device identity (name, manufacturer, model, serial number, firmware) in their `DeviceInfo`. Previously they registered only the device identifiers — if an event entity happened to be the device's first registration, the device entry was created without a name and the generated (sticky) entity_id degraded to the config-entry title (e.g. `event.<instance_name>_ch1` instead of `event.<device_name>_ch1`)
 - Reauthentication now reloads the config entry exactly once. The flow's entry update schedules a reload only when the registered update listener will not already do so (unloaded entry or unchanged data), replacing `ConfigFlow.async_update_reload_and_abort`, whose extra reload schedule alongside an update listener caused a double reload and is deprecated with HA 2026.12
 
+### Blueprints
+
+- `Show device error` no longer suggests parameters it can never receive. Its "Ignored error parameters" field named `CONFIG_PENDING` and `STICKY_UNREACH` as examples, and its description explained at length how a `CONFIG_PENDING` notification clears after a configuration transfer — but `homematic.device_error` only carries parameters whose name starts with `ERROR` or `SENSOR_ERROR`, so neither can ever reach this blueprint. The examples are now `ERROR_OVERHEAT` and `SENSOR_ERROR`, and the description states which parameters the event covers, that `ERROR_CODE` is excluded, and where CCU service messages are actually available (the `hub_service_messages` sensor). Reported in aiohomematic#3333; behaviour of the blueprint is unchanged
+
+### Documentation
+
+- README links the new [Events Reference](https://sukramj.github.io/aiohomematic/user/features/homeassistant_events/), which documents all seven events the integration fires on the HA event bus with their triggering parameters and payloads, and the Blueprints section now points to it — including the note that CCU service messages are not events
+
 ### Development
 
 - Added a `Makefile` as the entry point for all development tasks (`make help` lists every target): setup, code quality (ruff, mypy, pylint, bandit, codespell, yamllint, prettier, translations, prek), tests (incl. coverage, CI mode and the opt-in e2e suite), hassfest/HACS validation, running Home Assistant against `./config`, and housekeeping. Targets run through `script/run-in-env.sh`, so they work with or without an activated virtual environment. `CLAUDE.md` and `CONTRIBUTING.md` document the targets; the broken `cov.sh` (it referenced a non-existent `.coveragerc`) is superseded by `make test-cov-html` and was removed


### PR DESCRIPTION
## Why

Reported in [aiohomematic#3333](https://github.com/SukramJ/aiohomematic/discussions/3333). A user provoked `CONFIG_PENDING` on a device, saw it in the OpenCCU web UI, and got no notification from the `Show device error` blueprint.

The blueprint invited exactly that expectation:

- its **"Ignored error parameters"** field named `CONFIG_PENDING` and `STICKY_UNREACH` as the examples — implying both arrive via `homematic.device_error` and merely need filtering,
- its **description** explained at length how a `CONFIG_PENDING` notification clears once a pending configuration transfer completes.

Neither can happen. `homematic.device_error` is only created for parameters whose name starts with `ERROR` or `SENSOR_ERROR` (`DEVICE_ERROR_EVENTS` + `startswith` in aiohomematic's `model/event.py`), so `CONFIG_PENDING` and `STICKY_UNREACH` never reach this blueprint at all.

## What

- Examples replaced with parameters that actually arrive: `ERROR_OVERHEAT`, `SENSOR_ERROR`
- Description now states which parameters the event carries, that `ERROR_CODE` is filtered out by the integration (`FILTER_ERROR_EVENT_PARAMETERS`), and where CCU service messages are actually available — the `sensor.<instance>_hub_service_messages` sensor
- Version marker bumped to `v2026-08-02`
- README links the new Events Reference from the documentation table and from the Blueprints section

**The blueprint's behaviour is unchanged** — trigger, conditions and actions are untouched; only the description and the example text changed.

## Related

Documentation side of the same report: SukramJ/aiohomematic#3334 adds the full events reference (all seven events with triggering parameters and payloads) that the README now links to.

## Verification

- `make prek` passes (yamllint, prettier, codespell, translations)
- Blueprint parses as valid YAML with the `!input` tag resolved; inputs and description render as intended