### PR TITLE
chore(deps): bump aiohomematic and openccu-loom-client to 2026.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,8 @@ homematicip_local/
 
 ### Runtime Dependencies
 
-- **aiohomematic** (v2026.7.11) - Core async library for Homematic device communication
-- **aiohomematic-contract** (v2026.6.1) - Shared contract/event-type definitions
-- **aiohomematic-config** (v2026.5.0) - Device configuration metadata
+- **aiohomematic** (v2026.8.1) - Core async library for Homematic device communication
+- **aiohomematic-config** (v2026.8.0) - Device configuration metadata
 - **Home Assistant Core** - Minimum version: 2026.7.0+
 - **Python 3.14+** (target version for development)
 
@@ -131,7 +130,7 @@ homematicip_local/
 - **pylint** (4.0.5) - Code linting
 - **ruff** (0.15.15) - Fast Python linter and formatter
 - **prek** (0.4.4) - Git hooks manager (Rust-based pre-commit alternative)
-- **aiohomematic-test-support** (2026.7.11) - Mock test data
+- **aiohomematic-test-support** (2026.8.1) - Mock test data
 - **async-upnp-client** (0.47.0) - UPnP discovery
 - **uv** - Fast Python package installer (preferred over pip)
 
@@ -1127,7 +1126,7 @@ make hass
 - **Current Version:** 2.8.4
 - **Minimum HA Version:** 2026.7.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
-- **aiohomematic Version:** 2026.7.11
+- **aiohomematic Version:** 2026.8.1
 
 ### External Resources
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-07-29)
+# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-08-02)
 
 ## What's Changed
 
@@ -25,8 +25,10 @@
 
 ### Dependencies
 
-#### Bump aiohomematic to [2026.8.0](https://github.com/SukramJ/aiohomematic/compare/2026.7.6...2026.8.0)
+#### Bump aiohomematic to [2026.8.1](https://github.com/SukramJ/aiohomematic/compare/2026.7.6...2026.8.1)
 
+- Fix calculated sensors (`OPERATING_VOLTAGE_LEVEL`, `VAPOR_CONCENTRATION`, `DEW_POINT`, …) staying `unknown` after a Home Assistant restart instead of restoring their previous state (#3332). `CalculatedDataPoint` inherited its validity from `BaseDataPoint`, where `is_valid` only aggregates `is_refreshed` and `is_status_valid` of the source data points — a source that was read at startup but returned no usable value still counts as refreshed, so the calculated data point reported itself valid while its value was `None`. Since a previous state is only restored for data points that report themselves as invalid, the restore path never ran and the entity waited for the physical device to send again. Validity now requires every state-carrying source to be valid itself
+- Calculated data point validity is no longer gated by MASTER sources. Applying the ADR-0025 reasoning, only the readable VALUES sources carry state; MASTER paramset entries such as `LOW_BAT_LIMIT` are configuration inputs that a sleeping battery device may never deliver, and previously blocked `is_valid`, `is_refreshed` and `state_uncertain` of the whole calculated data point. A calculated data point without any readable VALUES source is now invalid rather than valid with `None`
 - Fix XML-RPC commands hanging forever when a connection goes half-open. The operational XML-RPC proxy is now created with a socket timeout (`rpc_timeout`, 60 s by default), matching backend detection; previously it had none, so a silently dropped or half-open (TLS) keep-alive connection made a `setValue`/`putParamset` block indefinitely in the proxy's single worker thread. Since each interface has exactly one worker, that wedged the interface's entire outgoing command path until Home Assistant was restarted — commands were neither sent nor failed, the only visible symptom being the 30 s optimistic rollback, while incoming events kept arriving over the separate callback path. A stuck request now aborts as a retryable `NoConnectionException`, which frees the worker thread and lets the command retry handler react
 - Fix data point names getting a redundant `ch<no>` postfix even when the channel's custom name is already unique (#3313). The postfix for parameters that exist on multiple channels of a device is now only appended when the channel name alone does not identify the channel — device-derived names, names following the `<name>:<no>` scheme, or several same-named channels providing the same parameter. A channel with a unique custom name (e.g. a status channel named `<sub device> Status`) keeps its clean entity name again
 - New `aiohomematic.device_semantics` module exposing the curated device-semantics classifications from openccu-data — first classification: `DOORBELL_MODELS`, the basis for the doorbell-model change above (#3304)
@@ -44,9 +46,9 @@
 
 - Tracking bump that raises its own `aiohomematic` and `openccu-data` floors to match the versions above. No functional change
 
-#### Bump openccu-loom-client to `2026.8.0` (pins `openccu-loom-types==0.2.4`)
+#### Bump openccu-loom-client to `2026.8.1` (pins `openccu-loom-types==0.2.5`)
 
-- Groundwork bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend. Advances the bundled loom client from `2026.7.6` to `2026.8.0` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.2.4`
+- Groundwork bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend. Advances the bundled loom client from `2026.7.6` to `2026.8.1` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.2.5`
 
 #### homematicip-local-frontend
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,9 +12,9 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.0",
+    "openccu-loom-client==2026.8.1",
     "aiohomematic-config==2026.8.0",
-    "aiohomematic==2026.8.0"
+    "aiohomematic==2026.8.1"
   ],
   "ssdp": [
     {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,12 +1,12 @@
 -r requirements_test_pre_commit.txt
 
 async_upnp_client==0.48.0
-aiohomematic-test-support==2026.8.0
-aiohomematic==2026.8.0
+aiohomematic-test-support==2026.8.1
+aiohomematic==2026.8.1
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.0
+openccu-loom-client==2026.8.1
 mypy<=2.1.0
 prek==0.4.11
 pur==7.4.0


### PR DESCRIPTION
## Summary

Dependency bump to the current reference stack, plus the matching 2.8.4 changelog entries.

- `aiohomematic` 2026.8.0 → **2026.8.1**
- `aiohomematic-test-support` 2026.8.0 → **2026.8.1**
- `openccu-loom-client` 2026.8.0 → **2026.8.1** (pins `openccu-loom-types==0.2.5`)
- `openccu-data` (2026.7.2) and `aiohomematic-config` (2026.8.0) unchanged
- `aiohomematic` stays the **last** entry in the manifest `requirements` list

## User-visible change

aiohomematic 2026.8.1 fixes calculated sensors (`OPERATING_VOLTAGE_LEVEL`, `VAPOR_CONCENTRATION`, `DEW_POINT`, …) staying `unknown` after a Home Assistant restart instead of restoring their previous state (aiohomematic#3332). `CalculatedDataPoint` inherited its validity from `BaseDataPoint`, where `is_valid` only aggregates `is_refreshed`/`is_status_valid` of the sources — a source read at startup that returned no usable value still counts as refreshed, so the calculated data point reported itself valid while its value was `None`, and the restore path (which only runs for data points reporting themselves invalid) never fired. Validity now requires every state-carrying source to be valid itself, and MASTER sources such as `LOW_BAT_LIMIT` no longer gate it.

## Out of scope

The loom client's own changes in 2026.8.1 (cover direction read from the daemon's `state` token, program execute availability) are **not** in the user-facing changelog entries — the loom-client bump keeps its existing groundwork one-liner, following #1224 / #1228 / #1230. Loom details stay out of scope until the backend leaves Beta.

## Also included

- `CLAUDE.md` version references refreshed (stale since the 2026.8.0 bump); the `aiohomematic-contract` line is dropped, it is not a manifest requirement
- 2.8.4 changelog date moved to the current day

## Test plan

- `make check` (prek hooks + tests with coverage): **867 passed, 8 skipped**, all hooks green, run against the bumped packages installed in the venv