### PR TITLE
chore(deps): bump openccu-loom-client to 2026.8.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,9 +46,9 @@
 
 - Tracking bump that raises its own `aiohomematic` and `openccu-data` floors to match the versions above. No functional change
 
-#### Bump openccu-loom-client to `2026.8.1` (pins `openccu-loom-types==0.2.5`)
+#### Bump openccu-loom-client to `2026.8.2` (pins `openccu-loom-types==0.2.6`)
 
-- Groundwork bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend. Advances the bundled loom client from `2026.7.6` to `2026.8.1` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.2.5`
+- Groundwork bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend. Advances the bundled loom client from `2026.7.6` to `2026.8.2` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.2.6`
 
 #### homematicip-local-frontend
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.1",
+    "openccu-loom-client==2026.8.2",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.1"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.1
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.1
+openccu-loom-client==2026.8.2
 mypy<=2.1.0
 prek==0.4.11
 pur==7.4.0


### PR DESCRIPTION
## Summary

Bundled loom-client bump plus the matching 2.8.4 changelog entry.

- `openccu-loom-client` 2026.8.1 → **2026.8.2** (pins `openccu-loom-types==0.2.6`)
- `aiohomematic` (2026.8.1), `aiohomematic-config` (2026.8.0) and `openccu-data` (2026.7.2) unchanged
- `aiohomematic` stays the **last** entry in the manifest `requirements` list

## No effect on the direct-CCU backend

The client release is compat-layer only: `CalculatedDpSensor` / `CalculatedDpBinarySensor` now take `is_valid` from the daemon's new `available` flag on the calc-dps record (API 3.13.0) instead of re-deriving it, so a dew point computed off a thermometer stuck at `OVERFLOW` no longer reads as an ordinary measurement. That code path is reachable only on the openccu-loom backend.

## Out of scope

Per #1224 / #1228 / #1230 / #1232, loom details stay out of the user-facing changelog until the backend leaves Beta — the loom-client entry keeps its groundwork one-liner and only moves its version and types pin.

## Note for loom users

The client's API guard derives from `DAEMON_API_VERSION`, so `connect()` now requires a daemon on API major 3 with minor ≥ 13, i.e. openccu-loom 0.52.9+.

## Test plan

- `make check` (prek hooks + tests with coverage): **867 passed, 8 skipped**, all 13 hooks green, run against `openccu-loom-client==2026.8.2` / `openccu-loom-types==0.2.6` installed in the venv