### PR TITLE
chore(deps): bump openccu-loom-client to 2026.8.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,9 +46,9 @@
 
 - Tracking bump that raises its own `aiohomematic` and `openccu-data` floors to match the versions above. No functional change
 
-#### Bump openccu-loom-client to `2026.8.2` (pins `openccu-loom-types==0.2.6`)
+#### Bump openccu-loom-client to `2026.8.3` (pins `openccu-loom-types==0.2.7`)
 
-- Groundwork bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend. Advances the bundled loom client from `2026.7.6` to `2026.8.2` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.2.6`
+- Groundwork bump for the openccu-loom backend (Beta); it has no runtime effect on the direct-CCU backend. Advances the bundled loom client from `2026.7.6` to `2026.8.3` and its transitively pinned `openccu-loom-types` from `0.1.53` to `0.2.7`
 
 #### homematicip-local-frontend
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.2",
+    "openccu-loom-client==2026.8.3",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.1"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.1
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.2
+openccu-loom-client==2026.8.3
 mypy<=2.1.0
 prek==0.4.11
 pur==7.4.0


### PR DESCRIPTION
## Summary

Bundled loom-client bump plus the matching 2.8.4 changelog entry.

- `openccu-loom-client` 2026.8.2 → **2026.8.3** (pins `openccu-loom-types==0.2.7`)
- `aiohomematic` (2026.8.1), `aiohomematic-config` (2026.8.0) and `openccu-data` (2026.7.2) unchanged
- `aiohomematic` stays the **last** entry in the manifest `requirements` list

## No effect on the direct-CCU backend

The client release is compat-layer only:

- `ProgramDpSwitch` gains a state and a write path (`PATCH /programs/{id}`) — it carried neither before, so the program switch never switched
- The store now owns the categorised sysvar and program twins instead of the hub coordinator caching copies, so hub entities are no longer frozen at their bootstrap value
- New `hub.program_changed` binding, and the "fetch system variables" service emits state changes for what it moved

All of that is reachable only on the openccu-loom backend.

## Out of scope

Per #1224 / #1228 / #1230 / #1232 / #1233, loom details stay out of the user-facing changelog until the backend leaves Beta — the loom-client entry keeps its groundwork one-liner and only moves its version and types pin.

## Note for loom users

`openccu_loom_types.DAEMON_API_VERSION` is now `3.14.0` (verified against the installed package), so the transport's API guard requires openccu-loom 0.52.10+.

## Test plan

- `make check` (prek hooks + tests with coverage): **867 passed, 8 skipped**, all 13 hooks green, run against `openccu-loom-client==2026.8.3` / `openccu-loom-types==0.2.7` installed in the venv