### PR TITLE
feat: render the openccu-loom daemon's own hub entity names

### DIFF
--- a/custom_components/homematicip_local/generic_entity.py
+++ b/custom_components/homematicip_local/generic_entity.py
@@ -526,6 +526,23 @@ class AioHomematicGenericHubEntity(Entity):
         This translated parameter will be used in the combined name.
         """
 
+        # A backend may have resolved the name itself. openccu-loom is the
+        # naming authority for its own hub entities and hands the localized
+        # name over the wire, in the language this integration asked for.
+        # Rendering it verbatim is what keeps the same words from living
+        # here and in the daemon's catalogue at once, drifting apart on the
+        # first edit to either. The data point keeps its English token in
+        # `name`, so the entity-description lookup in __init__ still matches
+        # on it and the entity keeps its icon, device class and category.
+        # aiohomematic data points carry no such attribute and fall through
+        # to the behaviour below unchanged.
+        #
+        # The isinstance check is not belt-and-braces: `getattr` on a mock
+        # answers with a truthy mock, and a bare truthiness test would make
+        # every mocked data point in a test suite take this branch.
+        if isinstance(resolved_name := getattr(self._data_point, "resolved_name", None), str) and resolved_name:
+            return resolved_name
+
         entity_name = self._data_point.name
 
         if (translated_name := super().name) is not None and not isinstance(translated_name, UndefinedType):

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.3",
+    "openccu-loom-client==2026.8.4",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.1"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ aiohomematic==2026.8.1
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.3
+openccu-loom-client==2026.8.4
 mypy<=2.1.0
 prek==0.4.11
 pur==7.4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,8 +8,8 @@ isal==1.8.0
 openccu-data>=2026.7.2
 openccu-loom-client==2026.8.4
 mypy<=2.1.0
-prek==0.4.11
+prek==0.4.12
 pur==7.4.0
 pylint==4.0.6
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.40
+pytest-homeassistant-custom-component-framework==1.0.42

--- a/tests/test_generic_entity.py
+++ b/tests/test_generic_entity.py
@@ -9,7 +9,7 @@ import pytest
 from aiohomematic.const import DataPointCategory
 from custom_components.homematicip_local.const import DOMAIN
 from custom_components.homematicip_local.control_unit import ControlUnit
-from custom_components.homematicip_local.generic_entity import AioHomematicGenericEntity
+from custom_components.homematicip_local.generic_entity import AioHomematicGenericEntity, AioHomematicGenericHubEntity
 
 # pylint: disable=protected-access
 
@@ -224,3 +224,88 @@ class TestScheduleSubdevice:
         # Entity stays on main device, not a separate schedule sub-device
         assert device_info["identifiers"] == {(DOMAIN, _DEVICE_IDENTIFIER)}
         assert device_info["via_device"] == (DOMAIN, _CENTRAL_NAME)
+
+
+def _create_mock_hub_data_point(
+    *,
+    name: str = "alarm_messages",
+    resolved_name: str | None = None,
+) -> MagicMock:
+    """Create a mock hub data point (no channel, no device-scoped naming)."""
+    mock_dp = MagicMock()
+    mock_dp.category = DataPointCategory.HUB_SENSOR
+    mock_dp.unique_id = "loom_abc1234567_hub_alarm-messages"
+    mock_dp.configure_mock(name=name)
+    mock_dp.available = True
+    mock_dp.enabled_default = True
+    mock_dp.is_valid = True
+    mock_dp.channel = None
+    # A mock answers every attribute, so an unset resolved_name has to be
+    # spelled out — otherwise the test cannot distinguish "the backend
+    # resolved a name" from "the backend has no such attribute at all".
+    mock_dp.resolved_name = resolved_name
+    return mock_dp
+
+
+def _create_hub_entity(*, mock_dp: MagicMock) -> AioHomematicGenericHubEntity:
+    """Create a hub entity with patched get_data_point + entity-description lookup."""
+    mock_cu = _create_mock_control_unit()
+    mock_central = MagicMock()
+    mock_central.event_bus.create_subscription_group.return_value = MagicMock()
+    mock_cu.central = mock_central
+    with (
+        patch(
+            "custom_components.homematicip_local.generic_entity.get_data_point",
+            side_effect=lambda data_point: data_point,
+        ),
+        patch(
+            "custom_components.homematicip_local.generic_entity.get_entity_description",
+            return_value=None,
+        ),
+        patch.object(AioHomematicGenericHubEntity, "_get_device_info", return_value={}),
+    ):
+        return AioHomematicGenericHubEntity(control_unit=mock_cu, data_point=mock_dp)
+
+
+class TestHubEntityNameFromBackend:
+    """
+    A backend that resolves its own entity names is rendered verbatim.
+
+    openccu-loom is the naming authority for its own hub entities and
+    hands the localized name over the wire. Rendering it here is what
+    keeps the same words from living in this integration and in the
+    daemon's catalogue at once, drifting apart on the first edit to
+    either.
+    """
+
+    def test_an_empty_resolved_name_does_not_blank_the_entity(self) -> None:
+        mock_dp = _create_mock_hub_data_point(name="alarm_messages", resolved_name="")
+        entity = _create_hub_entity(mock_dp=mock_dp)
+
+        assert entity.name == "alarm messages"
+
+    def test_resolved_name_wins(self) -> None:
+        mock_dp = _create_mock_hub_data_point(name="alarm_messages", resolved_name="Alarmmeldungen")
+        entity = _create_hub_entity(mock_dp=mock_dp)
+
+        assert entity.name == "Alarmmeldungen"
+
+    def test_the_token_is_untouched_so_descriptions_still_match(self) -> None:
+        """
+        The data point keeps its English token in `name`.
+
+        The entity-description lookup matches on it (`var_name_contains`),
+        and a localized token there would cost the entity its icon, device
+        class and category.
+        """
+        mock_dp = _create_mock_hub_data_point(name="alarm_messages", resolved_name="Alarmmeldungen")
+        _create_hub_entity(mock_dp=mock_dp)
+
+        assert mock_dp.name == "alarm_messages"
+
+    def test_without_a_resolved_name_the_previous_behaviour_stands(self) -> None:
+        """Aiohomematic data points carry no such attribute; nothing may change for them."""
+        mock_dp = _create_mock_hub_data_point(name="alarm_messages", resolved_name=None)
+        entity = _create_hub_entity(mock_dp=mock_dp)
+
+        assert entity.name == "alarm messages"


### PR DESCRIPTION
## Why

The openccu-loom daemon has been the naming authority for its own entities since 0.45.0 and names them in both locales — but those names only ever reached its MQTT discovery plane. This integration therefore rendered its own copy of the same words from `strings.json`: "Alarmmeldungen" lived in two places with nothing comparing them, and the two drift apart on the first edit to either.

For the daemon's new Security & Safety entities the second copy did not exist at all — they would have shown their raw tokens ("security smoke").

## What changes

With openccu-loom 0.54.0 the daemon serves its entity-name catalogue over REST, the client reads it **in Home Assistant's UI language** (which this integration already passes down as `locale=self.hass.config.language`), and a hub data point that carries a resolved name is rendered verbatim.

The data point keeps its English token in `name`. That is the core of the change: `entity_helpers/descriptions/hub.py` matches on `var_name_contains` against `data_point.name` — `ALARM_MESSAGES`, `SERVICE_MESSAGES`, `INSTALL_MODE_HMIP`, `INBOX_SENSOR_NAME`, `CONNECTIVITY_SENSOR_PREFIX`. A localized token there would cost the entity its icon, device class and category. Hence a change to the `name` property rather than a rename at the source.

Language coverage is unchanged: this integration ships `de` and `en`, and so does the daemon catalogue.

## No version bump, no changelog entry

The loom backend is Beta and its user-facing details stay out of the changelog until it ships — the same rule the existing entries state. The version stays **2.8.4**; only the bundled client pin moves.

## What does not change

**aiohomematic is untouched.** Its data points carry no such attribute and `GenericHubDataPointProtocol` does not declare it — the read is an optional `getattr`, so CCU-backed entities fall through to exactly today's behaviour. Nothing about the CCU backend changes.

The read additionally checks `isinstance` rather than mere truthiness: `getattr` on a mock answers with a truthy mock, and a plain truthiness test would pull every mocked data point in the suite into the new branch.

The `strings.json` entries for `alarm_messages`, `service_messages`, `inbox` and `connection_latency` stay: unused on the loom path now, still required for the aiohomematic path.

## Guards

Four tests in `tests/test_generic_entity.py`: the resolved name wins, the match token is untouched, without a resolved name the previous behaviour stands, and an empty name does not blank the entity. **Measured**: without the new branch, `test_resolved_name_wins` fails.

871 tests green, 8 skipped.

## Dependency

Requires `openccu-loom-client` **2026.8.4** (tagged; pinned here in `manifest.json` and `requirements_test.txt`), which needs openccu-loom **0.54.1** / API 5.2.0. CI here goes green once the client is on PyPI.