### PR TITLE
chore: bump version to 2.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This document provides comprehensive guidance for AI assistants working with the
 
 **Project Name:** Homematic(IP) Local for OpenCCU
 **Type:** Home Assistant Custom Integration
-**Version:** 2.8.4
+**Version:** 2.9.0
 **Primary Language:** Python 3.14+
 **Domain:** `homematicip_local`
 
@@ -1123,7 +1123,7 @@ make hass
 
 ### Version Information
 
-- **Current Version:** 2.8.4
+- **Current Version:** 2.9.0
 - **Minimum HA Version:** 2026.7.0+
 - **Python Target:** 3.14+ (CI tests on 3.14)
 - **aiohomematic Version:** 2026.8.1
@@ -1139,5 +1139,5 @@ make hass
 
 ---
 
-**Last Updated**: 2026-07-27
-**Version**: 2.8.4
+**Last Updated**: 2026-08-07
+**Version**: 2.9.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version [2.8.4](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.8.4) (2026-08-02)
+# Version [2.9.0](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.9.0) (2026-08-07)
 
 ## What's Changed
 

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -22,6 +22,6 @@
       "manufacturerURL": "https://openccu.de"
     }
   ],
-  "version": "2.8.4",
+  "version": "2.9.0",
   "zeroconf": ["_openccu-loom._tcp.local."]
 }

--- a/docs/architecture-comparison-aiohomematic-vs-loom.md
+++ b/docs/architecture-comparison-aiohomematic-vs-loom.md
@@ -18,7 +18,7 @@ integration v2.8.0): the Loom backend is **bundled but not user-selectable** —
 `LOOM_BACKEND_SELECTABLE = False` (`custom_components/homematicip_local/const.py:65`).
 It is groundwork for a future alternative, not a shipping feature.
 
-> **Update (2026-07-31, integration v2.8.4).** The master switch was removed.
+> **Update (2026-07-31, integration v2.9.0).** The master switch was removed.
 > The config flow now offers the Loom backend when it is relevant: an
 > mDNS-discovered daemon yields a discovery card, and the manual backend menu
 > appears when a Loom entry exists or a daemon discovery flow is in progress.
@@ -375,7 +375,7 @@ new DP class.
 ## 9. Maturity & feature parity
 
 - **`aiohomematic`:** the production default — 10/10 in this dimension.
-- **Loom:** bundled and, as of v2.8.4, reachable without a source-code change —
+- **Loom:** bundled and, as of v2.9.0, reachable without a source-code change —
   the flow surfaces it on daemon discovery or an existing loom entry (it was
   gated behind `LOOM_BACKEND_SELECTABLE = False` when this section was written).
   UI/flow/i18n are fully prepared (zeroconf `_openccu-loom._tcp`, active mDNS
@@ -407,7 +407,7 @@ own `"the daemon does not surface … yet"` comments were stale. The remaining w
 has therefore shifted from **daemon-side exposure** to **client-side
 consumption**: read the new G1 `color`/`color_mode`, consume `/hub/data-points`,
 `/event-groups` and the new hub push topics, and wire `set_on_time`. (The
-backend gate itself is gone as of v2.8.4 — see the update note in section 1.)
+backend gate itself is gone as of v2.9.0 — see the update note in section 1.)
 (Caveat: verified at the source level; the installed
 client `2026.6.21` / types `0.1.22` already reads `is_extended` and
 `color_temp_kelvin`/`effect`, but does not yet consume the brand-new
@@ -550,4 +550,4 @@ north-bound traffic.
   gaps were already-implemented or a client shape fix. What is left is a
   defensible product decision: have the Python client consume the new 1.18.0
   wire surface and accept the daemon's operational/SPOF costs. The flow-level
-  gate is no longer part of that decision — it was removed in v2.8.4.
+  gate is no longer part of that decision — it was removed in v2.9.0.


### PR DESCRIPTION
Bumps the integration version from `2.8.4` to `2.9.0`.

## Changes

| File | Change |
|---|---|
| `custom_components/homematicip_local/manifest.json` | `"version": "2.9.0"` |
| `changelog.md` | Heading + compare link of the unreleased entry → `2.8.3...2.9.0` |
| `CLAUDE.md` | Version fields (header, Quick Reference, footer) + "Last Updated" |
| `docs/architecture-comparison-aiohomematic-vs-loom.md` | 4 × "as of v2.8.4" → "v2.9.0" |

## Notes

- **Why the doc references moved too:** `2.8.4` was never tagged as a release — only the betas `2.8.4b1`…`b21` exist, the last real tag is `2.8.3`. The four statements in the loom architecture comparison ("the master switch was removed in v2.8.4") describe exactly the release that is now called `2.9.0`, so leaving them would point users at a version that never shipped. Historic references to actually released versions (e.g. `v2.8.0` in section 1) are untouched.
- **Changelog date left at `2026-08-02`.** If the release goes out later, the date still needs adjusting to the tag date.
- No code changes, so no test impact.