### PR TITLE
chore: openccu-loom-client 2026.8.8, and drop the stale version numbers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,13 @@
 
 ### Dependencies
 
-- Bump `openccu-loom-client` to `2026.8.7`
+- Bump `openccu-loom-client` to `2026.8.8` (pins `openccu-loom-types==0.3.6`,
+  daemon API 5.9.0). **This raises the minimum daemon: openccu-loom 0.55.1 or
+  newer.** The client refuses to connect to a lower API minor rather than
+  half-initializing against it, so an older daemon fails at `connect()` with a
+  clear message instead of producing bootstrap errors later. Entries on the
+  direct-CCU backend are unaffected — the client is only loaded for the loom
+  backend
 
 # Version [2.9.0](https://github.com/SukramJ/homematicip_local/compare/2.8.3...2.9.0) (2026-08-07)
 

--- a/custom_components/homematicip_local/control_unit.py
+++ b/custom_components/homematicip_local/control_unit.py
@@ -1455,9 +1455,10 @@ class ControlConfig:
             password=self._password or None,
             serial=self._serial,
             client_session=aiohttp_client.async_get_clientsession(self.hass),
-            # Sysvar/program marker filtering + enabled-by-default is resolved
-            # daemon-side (api >= 1.9.0, openccu-loom-client >= 2026.6.17), so
-            # the markers are no longer threaded into the loom backend.
+            # Sysvar/program marker filtering and enabled-by-default are
+            # resolved daemon-side, so this backend threads no markers
+            # through the way the direct-CCU path does. The versions that
+            # guarantee it are the pins in manifest.json.
             locale=self.hass.config.language,
         ).create_central()
         # The loom adapter duck-types CentralUnit; aiohomematic's Protocol

--- a/custom_components/homematicip_local/manifest.json
+++ b/custom_components/homematicip_local/manifest.json
@@ -12,7 +12,7 @@
   "loggers": ["aiohomematic", "aiohomematic_config", "openccu_loom_client"],
   "requirements": [
     "openccu-data==2026.7.2",
-    "openccu-loom-client==2026.8.7",
+    "openccu-loom-client==2026.8.8",
     "aiohomematic-config==2026.8.0",
     "aiohomematic==2026.8.1"
   ],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,10 +6,10 @@ aiohomematic==2026.8.1
 aiohomematic_config==2026.8.0
 isal==1.8.0
 openccu-data>=2026.7.2
-openccu-loom-client==2026.8.7
+openccu-loom-client==2026.8.8
 mypy<=2.1.0
 prek==0.4.12
 pur==7.4.0
 pylint==4.0.6
 pylint_strict_informational==0.1
-pytest-homeassistant-custom-component-framework==1.0.43
+pytest-homeassistant-custom-component-framework==1.0.44


### PR DESCRIPTION
Three things, all in the loom corner of this integration.

## The client pin moves to 2026.8.8 — and with it the minimum daemon

`openccu-loom-client==2026.8.8` in the manifest and the test requirements, which pins `openccu-loom-types==0.3.6` (daemon API 5.9.0).

**This raises the minimum daemon to openccu-loom 0.55.1.** The client's `_check_api_version` raises on a lower API minor of the same major rather than half-initializing against it, so an older daemon now fails at `connect()` with a clear message instead of producing bootstrap failures and event storms later. Entries on the direct-CCU backend are unaffected — the client is only imported for the loom backend.

The 2.9.1 changelog says so explicitly. A client bump that silently moves the floor is the kind of release note people otherwise discover through a bug report.

## A released changelog entry is restored

The bump had also been applied to the **2.9.0** section, which is released and records what that version actually shipped: `2026.8.6` / types `0.3.3`. Rewriting it would have made the history claim something that never happened. Restored to the value in the 2.9.0 tag.

## The stale comment in `control_unit.py`

It justified not threading sysvar/program markers into the loom backend with *"api >= 1.9.0, openccu-loom-client >= 2026.6.17"*. Both numbers had gone stale — the daemon API is four major versions past the one quoted, and the pin is two client releases on. A reader checking either against the tree would conclude the comment describes some other code.

The durable half is *why* the markers are absent, so that stays. For the versions it now points at `manifest.json`, which is the one place that decides them and moves when they move.

## Verification

`make lint` clean, `make test` 871 passed / 8 skipped.